### PR TITLE
Update js - Reset Guess Text Fix

### DIFF
--- a/phasmophobia_evidence_v2/widget.js
+++ b/phasmophobia_evidence_v2/widget.js
@@ -572,7 +572,7 @@ let getImpossibleEvidence = (possibleGhosts) => {
 }
 
 let updateGhostGuess = (guessText) => {
-  (guessText) ? $('#conclusion').html('No clue... yet') : $('#conclusion').html(checkEvidenceGhostMatch());
+  (guessText) ? $('#conclusion').html(guessText) : $('#conclusion').html(checkEvidenceGhostMatch());
 }
 
 let createGhostConclusionString = (conclusionString, ghostType) => {


### PR DESCRIPTION
Updated Line 575 to show correct Guess Text when resetting.
Note: did not do a lot of comprehensive testing, but appears to work.