### PR TITLE
Patch 3 - Single Optional Objectives

### DIFF
--- a/phasmophobia_evidence_v2/readme.md
+++ b/phasmophobia_evidence_v2/readme.md
@@ -1,4 +1,4 @@
-# Welcome to Phasmophobia Evidence V2
+# Welcome to Phasmophobia Evidence V2.1
 
 I made this widget for anyone who uses StreamElements that plays Phasmophobia. To see how the widget works, please click the video below:
 
@@ -17,7 +17,7 @@ I made this widget for anyone who uses StreamElements that plays Phasmophobia. T
 | Toggle Orbs | !go | Change Ghost Orbs to opposite of current state |
 | Toggle Ghost Writing | !gw | Change Ghost Writing to opposite of current state |
 | Toggle Freezing Temps | !gt | Change Freezing Temps to opposite of current state |
-| Optional Objectives | !oo "a" "b" "c" | Set the optional objectives. Replace a, b or c with the objective you'd like below |
+| Optional Objectives | !oo "a" "b" "c"<br />!oo "a" | Set the optional objectives. Replace a, b or c with the objective you'd like below |
 | Toggle Optional Objective 1 | !o1 | Toggles Optional Objective 1 from being marked or not |
 | Toggle Optional Objective 2 | !o2 | Toggles Optional Objective 2 from being marked or not |
 | Toggle Optional Objective 3 | !o3 | Toggles Optional Objective 3 from being marked or not |
@@ -53,6 +53,11 @@ To get `Crucifix Motion Salt`
 
     !oo cr photo ev
 
+Individual Objectives can be used and can be toggled on and off
+
+To get `Smudge`
+
+    !oo sm
 
 # How to Add to StreamElements?!?
 

--- a/phasmophobia_evidence_v2/readme.md
+++ b/phasmophobia_evidence_v2/readme.md
@@ -51,7 +51,7 @@ To get `Salt Photo Event`
 
 To get `Crucifix Motion Salt`
 
-    !oo cr photo ev
+    !oo cr motion sa
 
 Individual Objectives can be used and can be toggled on and off
 

--- a/phasmophobia_evidence_v2/widget.html
+++ b/phasmophobia_evidence_v2/widget.html
@@ -250,9 +250,9 @@ c-12 -20 -14 -14 -5 12 4 9 9 14 11 11 3 -2 0 -13 -6 -23z m-20 -50 c-12 -20
 
     <div class="optional-obj py-0.5" id="optional-obj">
       <div class="flex-1 flex justify-around hidden" id="optional-obj-container">
-        <div class="objective" id="objective-one">Motion</div>
-        <div class="objective" id="objective-two">Crucifix</div>
-        <div class="objective" id="objective-three">Photo</div>
+        <div class="objective" id="objective-one"></div>
+        <div class="objective" id="objective-two"></div>
+        <div class="objective" id="objective-three"></div>
       </div>
       <div class="objective" id="no-opt-objectives-container">
         {{noOptionalObjectivesMessage}}

--- a/phasmophobia_evidence_v2/widget.js
+++ b/phasmophobia_evidence_v2/widget.js
@@ -323,7 +323,7 @@ window.addEventListener('onEventReceived', function (obj) {
         if (commandArgument) {
           writeOutVersion(commandArgument);
         } else {
-          writeOutVersion(`Hello GlitchedMythos. Thank you for creating me. I am version 2.0 of your widget. I think everyone should check you out at twitch.tv/glitchedmythos. Also ${channelName} is absolutely AMAZING!`)
+          writeOutVersion(`Hello GlitchedMythos. Thank you for creating me. I am version 2.1 of your widget. I think everyone should check you out at twitch.tv/glitchedmythos. Also ${channelName} is absolutely AMAZING!`)
         }
       }
       break;
@@ -391,8 +391,11 @@ let resetEvidence = () => {
 }
 
 let resetOptional = () => {
+  $('#objective-one').text("");
   $('#objective-one').removeClass('strikethrough');
+  $('#objective-two').text("");
   $('#objective-two').removeClass('strikethrough');
+  $('#objective-three').text("");
   $('#objective-three').removeClass('strikethrough');
   $('#optional-obj-container').addClass('hidden');
   $('#no-opt-objectives-container').removeClass('hidden');
@@ -605,6 +608,9 @@ let updateOptionalObjectives = (command) => {
       }
     }
   }
+  else if (optObjCommands.length === 2) { // Note, since there are only 2 words, the length minimum is 2.
+    optObjectives.push(getOptObj(optObjCommands[1]));
+  }
 
   if (optObjectives.length === 3) {
     $('#optional-obj-container').removeClass('hidden');
@@ -612,6 +618,40 @@ let updateOptionalObjectives = (command) => {
     $('#objective-one').html(optObjectives[0]);
     $('#objective-two').html(optObjectives[1]);
     $('#objective-three').html(optObjectives[2]);
+  }
+  else if (optObjectives.length === 1) {
+    if ($('#objective-one').text() === optObjectives[0]) {
+      $('#objective-one').text("");
+      if (($('#objective-two').text() === "") && ($('#objective-three').text() === "")) {
+        $('#optional-obj-container').addClass('hidden');
+        $('#no-opt-objectives-container').removeClass('hidden');
+      }
+    }
+    else if ($('#objective-two').text() === optObjectives[0]) {
+      $('#objective-two').text("");
+      if (($('#objective-one').text() === "") && ($('#objective-three').text() === "")) {
+        $('#optional-obj-container').addClass('hidden');
+        $('#no-opt-objectives-container').removeClass('hidden');
+      }
+    }
+    else if ($('#objective-three').text() === optObjectives[0]) {
+      $('#objective-three').text("");
+      if (($('#objective-one').text() === "") && ($('#objective-two').text() === "")) {
+        $('#optional-obj-container').addClass('hidden');
+        $('#no-opt-objectives-container').removeClass('hidden');
+      }
+    }
+    else if ($('#objective-one').text() === "") {
+      $('#optional-obj-container').removeClass('hidden');
+      $('#no-opt-objectives-container').addClass('hidden');
+      $('#objective-one').text(optObjectives[0]);
+    }
+    else if ($('#objective-two').text() === "") {
+      $('#objective-two').html(optObjectives[0]);
+    }
+    else if ($('#objective-three').text() === "") {
+      $('#objective-three').html(optObjectives[0]);
+    }
   }
 }
 


### PR DESCRIPTION
Add single optional objectives (toggle-able on and off) using !oo "a" instead of !oo "a" "b" "c"

The widget will add into optional 1, then optional 2, then optional 3. If an objective is toggled off (in case you put salt instead of sanity... or some other issue), that optional objective will be cleared but the others will stay in their same spot.