### PR TITLE
Patch 1

### DIFF
--- a/phasmophobia_evidence_v3/readme.md
+++ b/phasmophobia_evidence_v3/readme.md
@@ -11,6 +11,7 @@ I made this widget for anyone who uses StreamElements that plays Phasmophobia. T
 | Name Reset | !gr | Reset the ghost |
 | Name Reset| !gr "name" | Reset the ghost with the name |
 | Name Input | !gn "name" | Change name to "name" |
+| Name Input<br />(Stream Deck) | !gfn "name"<br />!gsn "name" | Change either first or last name to "name" |
 | Toggle EMF | !ge | Change EMF to opposite of current state |
 | Toggle Spirit Box | !gs | Change Spirit Box to opposite of current state |
 | Toggle Fingerprints | !gf | Change Fingerprints to opposite of current state |
@@ -21,6 +22,8 @@ I made this widget for anyone who uses StreamElements that plays Phasmophobia. T
 | Toggle Optional Objective 1 | !o1 | Toggles Optional Objective 1 from being marked or not |
 | Toggle Optional Objective 2 | !o2 | Toggles Optional Objective 2 from being marked or not |
 | Toggle Optional Objective 3 | !o3 | Toggles Optional Objective 3 from being marked or not |
+| Map Input | !gm "map" | Set the map name. Replace with a command from the map list below |
+| Difficulty Input | !gd "difficulty" | Set the map name. Replace with a command from the map list below |
 | Set Counter Name | !setcounter "phrase" | Set's the phrase before the number in the counter |
 | Set Counter Number | !setcounternumber "num" | Set's the number in the counter to the number input |
 | Increment the counter by 1 | !counterup | Adds one to the counter number |
@@ -37,7 +40,7 @@ I made this widget for anyone who uses StreamElements that plays Phasmophobia. T
 | EMF | "em" "emf" |
 | Crucifix | "cr" "crucifix" |
 | Smudge Ghost (NON-Hunt) | "sm" "smudge" |
-| Parabolic Microphone | "pa" "parabolic" "mic" |
+| Parabolic Microphone<br />Note: Not In Game | "pa" "parabolic" "mic" |
 | Escape | "es" "escape" |
 | Smudge Ghost (During Hunt) | "hu" "hunt" |
 | <25% Sanity | "san "sanity" |
@@ -58,6 +61,45 @@ Individual Objectives can be used and can be toggled on and off
 To get `Smudge`
 
     !oo sm
+
+# Map Names and Difficulties
+
+| Map | Possible Phrases |
+|--|--|
+| Tanglewood | "ta" "tangle" "tanglewood" |
+| Edgefield | "ed" "edge" "edgefield" |
+| Ridgeview | "ri" "ridge" "ridgeview" |
+| Grafton | "gr" "grafton" |
+| Bleasdale | "bl" "bleasdale" |
+| High School | "hi" "high" "school" "brown" "brownstone" |
+| Prison | "pr" "prison" |
+| Asylum | "as" "asylum" |
+
+| Difficulty | Possible Phrases |
+|--|--|
+| Amateur | "am" "amateur" |
+| Intermediate | "int" "intermediate" |
+| Professional | "pro" "professional" |
+
+## Example Usage:
+
+To get `Grafton Farmhouse`
+
+    !gm gr
+
+To get `Brownstone High School`
+
+    !gm school
+
+To get `Professional` Difficulty
+
+    !gd pro
+
+Both Map and Difficulty can be combined in one map command
+
+To get `Asylum Intermediate`
+
+    !gm as int
 
 # How to Add to StreamElements?!?
 

--- a/phasmophobia_evidence_v3/readme.md
+++ b/phasmophobia_evidence_v3/readme.md
@@ -40,7 +40,7 @@ I made this widget for anyone who uses StreamElements that plays Phasmophobia. T
 | EMF | "em" "emf" |
 | Crucifix | "cr" "crucifix" |
 | Smudge Ghost (NON-Hunt) | "sm" "smudge" |
-| Parabolic Microphone<br />Note: Not In Game | "pa" "parabolic" "mic" |
+| Parabolic Microphone<br />Note: Not Currently Enabled In Game | "pa" "parabolic" "mic" |
 | Escape | "es" "escape" |
 | Smudge Ghost (During Hunt) | "hu" "hunt" |
 | <25% Sanity | "san "sanity" |

--- a/phasmophobia_evidence_v3/widget.css
+++ b/phasmophobia_evidence_v3/widget.css
@@ -44,6 +44,10 @@
   fill: {{evidenceImpossible}};
 }
 
+.evidencehidden {
+  opacity: 0;
+}
+
 .strikethrough {
   position: relative;
 }
@@ -142,7 +146,7 @@
 }
 
 .animated-box.in:after {
-  animation: frame-enter 1s forwards ease-in-out reverse, gradient-animation 4s ease-in-out infinite;
+  animation: frame-enter .5s forwards ease-in-out reverse, gradient-animation 5s ease-in-out infinite;
 }
 
 @keyframes gradient-animation {
@@ -212,4 +216,9 @@
 .counter-theme {
   font-size: {{counterFontSize}}px;
   color: {{counterFontColor}};
+}
+
+.map-theme {
+  font-size: {{mapFontSize}}px;
+  color: {{mapFontColor}};
 }

--- a/phasmophobia_evidence_v3/widget.css
+++ b/phasmophobia_evidence_v3/widget.css
@@ -146,7 +146,7 @@
 }
 
 .animated-box.in:after {
-  animation: frame-enter .5s forwards ease-in-out reverse, gradient-animation 5s ease-in-out infinite;
+  animation: frame-enter 1s forwards ease-in-out reverse, gradient-animation 4s ease-in-out infinite;
 }
 
 @keyframes gradient-animation {

--- a/phasmophobia_evidence_v3/widget.css
+++ b/phasmophobia_evidence_v3/widget.css
@@ -146,7 +146,7 @@
 }
 
 .animated-box.in:after {
-  animation: frame-enter 1s forwards ease-in-out reverse, gradient-animation 4s ease-in-out infinite;
+  animation: frame-enter 1s forwards ease-in-out reverse, gradient-animation {{animationDuration}}s ease-in-out infinite;
 }
 
 @keyframes gradient-animation {

--- a/phasmophobia_evidence_v3/widget.html
+++ b/phasmophobia_evidence_v3/widget.html
@@ -15,8 +15,14 @@ And I hope you don't get hunted yourself! :D -->
 
 <div class="phas-dashboard text-left {{dividerWidth}} divider-color {{dividerType}} p-1 h-screen flex flex-col"
     id="phas-dashboard">
-    <div class="name pb-0.5 flex-1" id="name">
-        {{noNameString}}
+    <div class="flex-row">
+        <div class="name pb-0.5 flex-1" id="name">
+            {{noNameString}}
+        </div>
+        <div class="flex flex-row" id="map-container">
+            <div class="map-theme mr-0.5 pb-0.5" id="map-name">{{noMapString}}</div>
+            <div class="map-theme" id="map-difficulty"></div>
+        </div>
     </div>
 
     <div class="py-0.5 flex-grow">

--- a/phasmophobia_evidence_v3/widget.js
+++ b/phasmophobia_evidence_v3/widget.js
@@ -52,9 +52,9 @@ let phantom = '110010',
   yurei = '010110',
   poltergeist = '001011',
   spirit = '001101',
-  demon = '011100';
-//  yokai = '001110';
-//  hantu = '000111';
+  demon = '011100',
+  yokai = '001110',
+  hantu = '000111';
 
 let channelName;
 
@@ -140,65 +140,119 @@ window.addEventListener('onWidgetLoad', function (obj) {
     tooMuchEvidence: (fieldData['impossibleConclusionString']) ?
       fieldData['impossibleConclusionString'] : 'Too Much Evidence'
   };
-  config.ghosts = [
-    {
-      "type": 'Banshee',
-      "conclusion": createGhostConclusionString(fieldData['bansheeString'], 'Banshee'),
-      "evidence": '110001'
-    }, {
-      "type": "Demon",
-      "conclusion": createGhostConclusionString(fieldData['demonString'], 'Demon'),
-      "evidence": '011100'
-    }, {
-      "type": "Jinn",
-      "conclusion": createGhostConclusionString(fieldData['jinnString'], 'Jinn'),
-      "evidence": '101010'
-    }, {
-      "type": "Mare",
-      "conclusion": createGhostConclusionString(fieldData['mareString'], 'Mare'),
-      "evidence": '011010'
-    }, {
-      "type": "Oni",
-      "conclusion": createGhostConclusionString(fieldData['oniString'], 'Oni'),
-      "evidence": '101100'
-    }, {
-      "type": "Phantom",
-      "conclusion": createGhostConclusionString(fieldData['phantomString'], 'Phantom'),
-      "evidence": '110010'
-    }, {
-      "type": "Poltergeist",
-      "conclusion": createGhostConclusionString(fieldData['poltergeistString'], 'Poltergeist'),
-      "evidence": '001011'
-    }, {
-      "type": "Revenant",
-      "conclusion": createGhostConclusionString(fieldData['revenantString'], 'Revenant'),
-      "evidence": '100101'
-    }, {
-      "type": "Shade",
-      "conclusion": createGhostConclusionString(fieldData['shadeString'], 'Shade'),
-      "evidence": '100110'
-    }, {
-      "type": "Spirit",
-      "conclusion": createGhostConclusionString(fieldData['spiritString'], 'Spirit'),
-      "evidence": '001101'
-    }, {
-      "type": "Wraith",
-      "conclusion": createGhostConclusionString(fieldData['wraithString'], 'Wraith'),
-      "evidence": '011001'
-    }, {
-      "type": "Yurei",
-      "conclusion": createGhostConclusionString(fieldData['yureiString'], 'Yurei'),
-      "evidence": '010110'
-    }/*, {
-      "type": "Yokai",
-      "conclusion": createGhostConclusionString(fieldData['yokaiString'], 'Yokai'),
-      "evidence": '001110'
-    }, {
-      "type": "Hantu",
-      "conclusion": createGhostConclusionString(fieldData['hantuString'], 'Hantu'),
-      "evidence": '000111'
-    }*/
-  ];
+  if (fieldData['betaBranch'] === 'yes') {
+    config.ghosts = [
+      {
+        "type": 'Banshee',
+        "conclusion": createGhostConclusionString(fieldData['bansheeString'], 'Banshee'),
+        "evidence": '110001'
+      }, {
+        "type": "Demon",
+        "conclusion": createGhostConclusionString(fieldData['demonString'], 'Demon'),
+        "evidence": '011100'
+      }, {
+        "type": "Jinn",
+        "conclusion": createGhostConclusionString(fieldData['jinnString'], 'Jinn'),
+        "evidence": '101010'
+      }, {
+        "type": "Mare",
+        "conclusion": createGhostConclusionString(fieldData['mareString'], 'Mare'),
+        "evidence": '011010'
+      }, {
+        "type": "Oni",
+        "conclusion": createGhostConclusionString(fieldData['oniString'], 'Oni'),
+        "evidence": '101100'
+      }, {
+        "type": "Phantom",
+        "conclusion": createGhostConclusionString(fieldData['phantomString'], 'Phantom'),
+        "evidence": '110010'
+      }, {
+        "type": "Poltergeist",
+        "conclusion": createGhostConclusionString(fieldData['poltergeistString'], 'Poltergeist'),
+        "evidence": '001011'
+      }, {
+        "type": "Revenant",
+        "conclusion": createGhostConclusionString(fieldData['revenantString'], 'Revenant'),
+        "evidence": '100101'
+      }, {
+        "type": "Shade",
+        "conclusion": createGhostConclusionString(fieldData['shadeString'], 'Shade'),
+        "evidence": '100110'
+      }, {
+        "type": "Spirit",
+        "conclusion": createGhostConclusionString(fieldData['spiritString'], 'Spirit'),
+        "evidence": '001101'
+      }, {
+        "type": "Wraith",
+        "conclusion": createGhostConclusionString(fieldData['wraithString'], 'Wraith'),
+        "evidence": '011001'
+      }, {
+        "type": "Yurei",
+        "conclusion": createGhostConclusionString(fieldData['yureiString'], 'Yurei'),
+        "evidence": '010110'
+      }, {
+        "type": "Yokai",
+        "conclusion": createGhostConclusionString(fieldData['yokaiString'], 'Yokai'),
+        "evidence": '001110'
+      }, {
+        "type": "Hantu",
+        "conclusion": createGhostConclusionString(fieldData['hantuString'], 'Hantu'),
+        "evidence": '000111'
+      }
+    ];
+  } else {
+    config.ghosts = [
+      {
+        "type": 'Banshee',
+        "conclusion": createGhostConclusionString(fieldData['bansheeString'], 'Banshee'),
+        "evidence": '110001'
+      }, {
+        "type": "Demon",
+        "conclusion": createGhostConclusionString(fieldData['demonString'], 'Demon'),
+        "evidence": '011100'
+      }, {
+        "type": "Jinn",
+        "conclusion": createGhostConclusionString(fieldData['jinnString'], 'Jinn'),
+        "evidence": '101010'
+      }, {
+        "type": "Mare",
+        "conclusion": createGhostConclusionString(fieldData['mareString'], 'Mare'),
+        "evidence": '011010'
+      }, {
+        "type": "Oni",
+        "conclusion": createGhostConclusionString(fieldData['oniString'], 'Oni'),
+        "evidence": '101100'
+      }, {
+        "type": "Phantom",
+        "conclusion": createGhostConclusionString(fieldData['phantomString'], 'Phantom'),
+        "evidence": '110010'
+      }, {
+        "type": "Poltergeist",
+        "conclusion": createGhostConclusionString(fieldData['poltergeistString'], 'Poltergeist'),
+        "evidence": '001011'
+      }, {
+        "type": "Revenant",
+        "conclusion": createGhostConclusionString(fieldData['revenantString'], 'Revenant'),
+        "evidence": '100101'
+      }, {
+        "type": "Shade",
+        "conclusion": createGhostConclusionString(fieldData['shadeString'], 'Shade'),
+        "evidence": '100110'
+      }, {
+        "type": "Spirit",
+        "conclusion": createGhostConclusionString(fieldData['spiritString'], 'Spirit'),
+        "evidence": '001101'
+      }, {
+        "type": "Wraith",
+        "conclusion": createGhostConclusionString(fieldData['wraithString'], 'Wraith'),
+        "evidence": '011001'
+      }, {
+        "type": "Yurei",
+        "conclusion": createGhostConclusionString(fieldData['yureiString'], 'Yurei'),
+        "evidence": '010110'
+      }
+    ];
+  }
 
   let displayName = (fieldData['displayName'] === 'yes') ? true : false;
   let displayCounter = (fieldData['displayCounter'] === 'yes') ? true : false;

--- a/phasmophobia_evidence_v3/widget.js
+++ b/phasmophobia_evidence_v3/widget.js
@@ -115,7 +115,6 @@ window.addEventListener('onWidgetLoad', function (obj) {
   greyOutType = fieldData['fullEvidence'];
   greyOutInvalidEvidence = (fieldData['greyOutInvalidEvidence'] === 'yes') ? true : false;
   autoCapitalizeName = (fieldData['autoCapitalize'] === 'yes') ? true : false;
-  console.log(autoCapitalizeName);
 
   config.allowVIPS = (fieldData['allowVIPS'] === 'yes') ? true : false;
   config.vipCommandAccess = (config.allowVIPS) ? true : false;

--- a/phasmophobia_evidence_v3/widget.json
+++ b/phasmophobia_evidence_v3/widget.json
@@ -86,13 +86,13 @@
   "mapNameCommand": {
     "type": "string",
     "label": "Set Map Command",
-    "value": "!gmap",
+    "value": "!gm",
     "group": "Commands"
   },
   "mapDiffCommand": {
     "type": "string",
     "label": "Set Difficulty Command",
-    "value": "!gdiff",
+    "value": "!gd",
     "group": "Commands"
   },
   "setCounterNameCommand": {

--- a/phasmophobia_evidence_v3/widget.json
+++ b/phasmophobia_evidence_v3/widget.json
@@ -343,6 +343,15 @@
     },
     "group": "Theming - Gradient Border"
   },
+  "animationDuration": {
+    "type": "slider",
+    "label": "Animate Duration (sec)",
+    "value": "4",
+    "min": "1",
+    "max": "10",
+    "step": 0.5,
+    "group": "Theming - Gradient Border"
+  },
   "animatedBorderColor": {
     "type": "colorpicker",
     "label": "Border Color",

--- a/phasmophobia_evidence_v3/widget.json
+++ b/phasmophobia_evidence_v3/widget.json
@@ -119,6 +119,16 @@
     "value": "!counterdown",
     "group": "Commands"
   },
+  "betaBranch": {
+    "type": "dropdown",
+    "label": "Beta Branch? (Yokai/Hantu)",
+    "value": "no",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Optionals"
+  },
   "displayName": {
     "type": "dropdown",
     "label": "Display Name",

--- a/phasmophobia_evidence_v3/widget.json
+++ b/phasmophobia_evidence_v3/widget.json
@@ -2,13 +2,25 @@
   "resetCommand": {
     "type": "string",
     "label": "Name Reset Command",
-    "value": "!ghostreset",
+    "value": "!gr",
     "group": "Commands"
   },
   "nameCommand": {
     "type": "string",
     "label": "Name Input Command",
-    "value": "!ghostname",
+    "value": "!gn",
+    "group": "Commands"
+  },
+  "firstnameCommand": {
+    "type": "string",
+    "label": "First Name Input Command",
+    "value": "!gfn",
+    "group": "Commands"
+  },
+  "surnameCommand": {
+    "type": "string",
+    "label": "Surname Input Command",
+    "value": "!gsn",
     "group": "Commands"
   },
   "emfCommand": {
@@ -71,6 +83,18 @@
     "value": "!o3",
     "group": "Commands"
   },
+  "mapNameCommand": {
+    "type": "string",
+    "label": "Set Map Command",
+    "value": "!gmap",
+    "group": "Commands"
+  },
+  "mapDiffCommand": {
+    "type": "string",
+    "label": "Set Difficulty Command",
+    "value": "!gdiff",
+    "group": "Commands"
+  },
   "setCounterNameCommand": {
     "type": "string",
     "label": "Set Counter Name Command",
@@ -105,6 +129,16 @@
     },
     "group": "Optionals"
   },
+  "autoCapitalize": {
+    "type": "dropdown",
+    "label": "Auto Capitalize Name",
+    "value": "yes",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Optionals"
+  },
   "displayConclusion": {
     "type": "dropdown",
     "label": "Display Conclusion",
@@ -118,6 +152,16 @@
   "displayCounter": {
     "type": "dropdown",
     "label": "Display Counter",
+    "value": "yes",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Optionals"
+  },
+  "displayMap": {
+    "type": "dropdown",
+    "label": "Display Map Name",
     "value": "yes",
     "options": {
       "yes": "Yes",
@@ -142,6 +186,17 @@
     "options": {
       "yes": "Yes",
       "no": "No"
+    },
+    "group": "Optionals"
+  },
+  "fullEvidence": {
+    "type": "dropdown",
+    "label": "Evidence Color after Completion",
+    "value": "impossible",
+    "options": {
+      "impossible": "Impossible Color",
+      "inactive": "Inactive Color",
+      "hidden": "Hidden from Widget"
     },
     "group": "Optionals"
   },
@@ -357,6 +412,18 @@
     "value": 24,
     "group": "Theming - Counter"
   },
+  "mapFontColor": {
+    "type": "colorpicker",
+    "label": "Map Name Color",
+    "value": "rgba(192,192,192,1)",
+    "group": "Theming - Map Name"
+  },
+  "mapFontSize": {
+    "type": "number",
+    "label": "Map Name Font Size",
+    "value": 24,
+    "group": "Theming - Map Name"
+  },
   "evidenceActive": {
     "type": "colorpicker",
     "label": "Evidence - Active",
@@ -391,6 +458,12 @@
     "type": "text",
     "label": "Ghost Name: [name]",
     "value": "Name: [name]",
+    "group": "Name Messages"
+  },
+  "noMapString": {
+    "type": "text",
+    "label": "No Map Selected",
+    "value": "No Map Selected...",
     "group": "Name Messages"
   },
   "counterDefaultString": {
@@ -492,6 +565,18 @@
   "yureiString": {
     "type": "text",
     "label": "Yurei - Leave empty 4 default",
+    "value": "",
+    "group": "Conclusion Messages"
+  },
+  "yokaiString": {
+    "type": "text",
+    "label": "Yokai - Leave empty 4 default",
+    "value": "",
+    "group": "Conclusion Messages"
+  },
+  "hantuString": {
+    "type": "text",
+    "label": "Hantu - Leave empty 4 default",
     "value": "",
     "group": "Conclusion Messages"
   }


### PR DESCRIPTION
Readme:
-Added explanation for Name commands using Stream Deck and Map and Difficulty inputs

HTML:
-Updated to add the Map Name and Difficulty under the Ghost Name

CSS:
-Added css style for hiding remaining evidence once three are found (instead of coloring it impossible or inactive).
-Added css style for Map name
-Updated css style for animated border to allow for different gradient duration

JS:
-Added Two New Ghost Types: Yokai and Hantu, which can be enabled under the widget options (Optional section) -- Note, this is different from GlitchedMythos's plans for Version 3
-Added First Name and Last Name commands for use with Stream Decks
-Added ability to Auto-capitalize names when entering them
-Added Map Name and Difficulty commands -- Note: Map and Difficulty can be set as one command if desired
-Added ability to Hide remaining evidence once a ghost has been found

JSON:
-Added First Name and Last Name Commands for use with Stream Deck
-Added Map Name and Difficulty Commands
-Added "Beta Branch" toggle (Optional Section) to allow for Yokai and Hantu to be available ghosts when released by DK on Beta Branch
-Added slider to allow for different gradient duration
-Added Map Font color and size
-Added Text for when no map is selected
-Change how evidence is handled once a ghost is found (Impossible, Inactive, Hidden)
-Added Yokai and Hantu conclusion messages
