### PR TITLE
Minor Bug Fixes

### DIFF
--- a/phasmophobia_evidence_v3/widget.js
+++ b/phasmophobia_evidence_v3/widget.js
@@ -783,7 +783,7 @@ const resetName = (newName, state) => {
       ? camelCase(newName)
       : newName;
   } else {
-    state.ghostName = config.nameStrings.noNameString;
+    state.ghostName = "";
   }
 };
 

--- a/phasmophobia_evidence_v3/widget.js
+++ b/phasmophobia_evidence_v3/widget.js
@@ -535,6 +535,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
   } else {
     if (!displayLocation) {
       $(`#location-name`).addClass("hidden");
+      $(`#location-difficulty`).addClass("hidden");
     }
 
     if (!displayBoner && !displayOuija) {

--- a/phasmophobia_evidence_v3/widget.js
+++ b/phasmophobia_evidence_v3/widget.js
@@ -325,13 +325,13 @@ window.addEventListener("onWidgetLoad", function (obj) {
       );
     },
     [fieldData["vipToggleOnCommand"]]: (data) => {
-      runCommandWithPermission(PERMISSION_MOD, data, _toggleOptionalObjective, [
+      runCommandWithPermission(PERMISSION_MOD, data, _toggleVIPAccessibility, [
         true,
       ]);
     },
     [fieldData["vipToggleOffCommand"]]: (data) => {
-      runCommandWithPermission(PERMISSION_MOD, data, _toggleOptionalObjective, [
-        true,
+      runCommandWithPermission(PERMISSION_MOD, data, _toggleVIPAccessibility, [
+        false,
       ]);
     },
     [fieldData["setCounterNameCommand"]]: (data) => {

--- a/phasmophobia_evidence_v3/widget.json
+++ b/phasmophobia_evidence_v3/widget.json
@@ -466,7 +466,7 @@
   },
   "bonerIconActiveColor": {
     "type": "colorpicker",
-    "label": "Boner Inactive Color",
+    "label": "Boner Active Color",
     "value": "rgba(0, 230, 64, 1)",
     "group": "Theming - Location"
   },
@@ -484,7 +484,7 @@
   },
   "ouijaIconActiveColor": {
     "type": "colorpicker",
-    "label": "Ouija Inactive Color",
+    "label": "Ouija Active Color",
     "value": "rgba(0, 230, 64, 1)",
     "group": "Theming - Location"
   },


### PR DESCRIPTION
Ghost Name would think it was noNameString and therefore would replace only the first or last word of the string if using !gfn and !gsn. Updating to blank should make it use the noNameString as part of updateNameDOM

Ouija and Boner active color text was inaccurately labeled as "Inactive" and has been fixed.