### PR TITLE
Add Second Counter, Minor Fixes

### DIFF
--- a/phasmophobia_evidence_v3/readme.md
+++ b/phasmophobia_evidence_v3/readme.md
@@ -27,10 +27,10 @@ I made this widget for anyone who uses StreamElements that plays Phasmophobia. T
 | Toggle Optional Objective 1 | !o1 | Toggles Optional Objective 1 from being marked or not |
 | Toggle Optional Objective 2 | !o2 | Toggles Optional Objective 2 from being marked or not |
 | Toggle Optional Objective 3 | !o3 | Toggles Optional Objective 3 from being marked or not |
-| Set Counter Name | !setcounter "phrase" | Set's the phrase before the number in the counter |
-| Set Counter Number | !setcounternumber "num" | Set's the number in the counter to the number input |
-| Increment the counter by 1 | !counterup | Adds one to the counter number |
-| Decrement the counter by 1 | !counterdown | Subtracts one from the counter number |
+| Set Counter Name | !setcounter "phrase"<br />!setcounter2 "phrase" | Set's the phrase before the number in the counter |
+| Set Counter Number | !setcounternumber "num"<br />!setcounter2number "num" | Set's the number in the counter to the number input |
+| Increment the counter by 1 | !counterup<br />!counter2up | Adds one to the counter number |
+| Decrement the counter by 1 | !counterdown<br />!counter2down | Subtracts one from the counter number |
 
 # Optional Objectives
 
@@ -70,6 +70,7 @@ To get `Smudge`
 | Map | Possible Phrases |
 |--|--|
 | Tanglewood | "ta" "tangle" "tanglewood" |
+| Willow | "wi" "will" "willow" |
 | Edgefield | "ed" "edge" "edgefield" |
 | Ridgeview | "ri" "ridge" "ridgeview" |
 | Grafton | "gr" "grafton" |

--- a/phasmophobia_evidence_v3/readme.md
+++ b/phasmophobia_evidence_v3/readme.md
@@ -1,4 +1,4 @@
-# Welcome to Phasmophobia Evidence V3.0
+# Welcome to Phasmophobia Evidence V3.4
 
 I made this widget for anyone who uses StreamElements that plays Phasmophobia. To see how the widget works, please click the video below:
 

--- a/phasmophobia_evidence_v3/widget.css
+++ b/phasmophobia_evidence_v3/widget.css
@@ -188,19 +188,19 @@
 
 @keyframes frame-enter {
   0% {
-    clip-path: polygon(0% 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) calc(100% - {{animatedBorderWidth}}px), {{animatedBorderWidth}}px calc(100% - {{animatedBorderWidth}}px), {{animatedBorderWidth}}px 100%, 100% 100%, 100% 0%, 0% 0%);
+    clip-path: polygon(0% 100%, {{borderWidth}}px 100%, {{borderWidth}}px {{borderWidth}}px, calc(100% - {{borderWidth}}px) {{borderWidth}}px, calc(100% - {{borderWidth}}px) calc(100% - {{borderWidth}}px), {{borderWidth}}px calc(100% - {{borderWidth}}px), {{borderWidth}}px 100%, 100% 100%, 100% 0%, 0% 0%);
   }
   25% {
-    clip-path: polygon(0% 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) calc(100% - {{animatedBorderWidth}}px), calc(100% - {{animatedBorderWidth}}px) calc(100% - {{animatedBorderWidth}}px), calc(100% - {{animatedBorderWidth}}px) 100%, 100% 100%, 100% 0%, 0% 0%);
+    clip-path: polygon(0% 100%, {{borderWidth}}px 100%, {{borderWidth}}px {{borderWidth}}px, calc(100% - {{borderWidth}}px) {{borderWidth}}px, calc(100% - {{borderWidth}}px) calc(100% - {{borderWidth}}px), calc(100% - {{borderWidth}}px) calc(100% - {{borderWidth}}px), calc(100% - {{borderWidth}}px) 100%, 100% 100%, 100% 0%, 0% 0%);
   }
   50% {
-    clip-path: polygon(0% 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) {{animatedBorderWidth}}px, 100% 0%, 0% 0%);
+    clip-path: polygon(0% 100%, {{borderWidth}}px 100%, {{borderWidth}}px {{borderWidth}}px, calc(100% - {{borderWidth}}px) {{borderWidth}}px, calc(100% - {{borderWidth}}px) {{borderWidth}}px, calc(100% - {{borderWidth}}px) {{borderWidth}}px, calc(100% - {{borderWidth}}px) {{borderWidth}}px, calc(100% - {{borderWidth}}px) {{borderWidth}}px, 100% 0%, 0% 0%);
   }
   75% {
-    -webkit-clip-path: polygon(0% 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px {{animatedBorderWidth}}px, {{animatedBorderWidth}}px {{animatedBorderWidth}}px, {{animatedBorderWidth}}px {{animatedBorderWidth}}px, {{animatedBorderWidth}}px {{animatedBorderWidth}}px, {{animatedBorderWidth}}px {{animatedBorderWidth}}px, {{animatedBorderWidth}}px {{animatedBorderWidth}}px, {{animatedBorderWidth}}px 0%, 0% 0%);
+    -webkit-clip-path: polygon(0% 100%, {{borderWidth}}px 100%, {{borderWidth}}px {{borderWidth}}px, {{borderWidth}}px {{borderWidth}}px, {{borderWidth}}px {{borderWidth}}px, {{borderWidth}}px {{borderWidth}}px, {{borderWidth}}px {{borderWidth}}px, {{borderWidth}}px {{borderWidth}}px, {{borderWidth}}px 0%, 0% 0%);
   }
   100% {
-    -webkit-clip-path: polygon(0% 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px 100%, 0% 100%);
+    -webkit-clip-path: polygon(0% 100%, {{borderWidth}}px 100%, {{borderWidth}}px 100%, {{borderWidth}}px 100%, {{borderWidth}}px 100%, {{borderWidth}}px 100%, {{borderWidth}}px 100%, {{borderWidth}}px 100%, {{aborderWidth}}px 100%, 0% 100%);
   }
 }
 

--- a/phasmophobia_evidence_v3/widget.css
+++ b/phasmophobia_evidence_v3/widget.css
@@ -131,7 +131,7 @@
 } */
 
 .animated-box {
-  border-radius: {{animatedBorderRadius}}px;
+  border-radius: {{borderRadius}}px;
 }
 
 .animated-box h1 {
@@ -147,7 +147,7 @@
 /* The animation starts here */
 .animated-box {
   position: relative;
-  border-radius: {{animatedBorderRadius}}px;
+  border-radius: {{borderRadius}}px;
 }
 
 .animated-box:after {
@@ -157,9 +157,9 @@
   left: 0;
   right: 0;
   bottom: 0;
-  border-radius: {{animatedBorderRadius}}px;
+  border-radius: {{borderRadius}}px;
   background: linear-gradient({{animatedBorderAngle}}deg, {{animatedBorderColor}}, {{animatedBorderColorTwo}}, {{animatedBorderColorThree}});
-  clip-path: polygon(0% 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) calc(100% - {{animatedBorderWidth}}px), {{animatedBorderWidth}}px calc(100% - {{animatedBorderWidth}}px), {{animatedBorderWidth}}px 100%, 100% 100%, 100% 0%, 0% 0%);
+  clip-path: polygon(0% 100%, {{borderWidth}}px 100%, {{borderWidth}}px {{borderWidth}}px, calc(100% - {{borderWidth}}px) {{borderWidth}}px, calc(100% - {{borderWidth}}px) calc(100% - {{borderWidth}}px), {{borderWidth}}px calc(100% - {{borderWidth}}px), {{borderWidth}}px 100%, 100% 100%, 100% 0%, 0% 0%);
 }
 
 .animated-box-100:after {

--- a/phasmophobia_evidence_v3/widget.css
+++ b/phasmophobia_evidence_v3/widget.css
@@ -131,7 +131,7 @@
 } */
 
 .animated-box {
-  border-radius: {{borderRadius}}px;
+  border-radius: {{animatedBorderRadius}}px;
 }
 
 .animated-box h1 {
@@ -147,7 +147,7 @@
 /* The animation starts here */
 .animated-box {
   position: relative;
-  border-radius: {{borderRadius}}px;
+  border-radius: {{animatedBorderRadius}}px;
 }
 
 .animated-box:after {
@@ -157,9 +157,9 @@
   left: 0;
   right: 0;
   bottom: 0;
-  border-radius: {{borderRadius}}px;
+  border-radius: {{animatedBorderRadius}}px;
   background: linear-gradient({{animatedBorderAngle}}deg, {{animatedBorderColor}}, {{animatedBorderColorTwo}}, {{animatedBorderColorThree}});
-  clip-path: polygon(0% 100%, {{borderWidth}}px 100%, {{borderWidth}}px {{borderWidth}}px, calc(100% - {{borderWidth}}px) {{borderWidth}}px, calc(100% - {{borderWidth}}px) calc(100% - {{borderWidth}}px), {{borderWidth}}px calc(100% - {{borderWidth}}px), {{borderWidth}}px 100%, 100% 100%, 100% 0%, 0% 0%);
+  clip-path: polygon(0% 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) calc(100% - {{animatedBorderWidth}}px), {{animatedBorderWidth}}px calc(100% - {{animatedBorderWidth}}px), {{animatedBorderWidth}}px 100%, 100% 100%, 100% 0%, 0% 0%);
 }
 
 .animated-box-100:after {
@@ -188,19 +188,19 @@
 
 @keyframes frame-enter {
   0% {
-    clip-path: polygon(0% 100%, {{borderWidth}}px 100%, {{borderWidth}}px {{borderWidth}}px, calc(100% - {{borderWidth}}px) {{borderWidth}}px, calc(100% - {{borderWidth}}px) calc(100% - {{borderWidth}}px), {{borderWidth}}px calc(100% - {{borderWidth}}px), {{borderWidth}}px 100%, 100% 100%, 100% 0%, 0% 0%);
+    clip-path: polygon(0% 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) calc(100% - {{animatedBorderWidth}}px), {{animatedBorderWidth}}px calc(100% - {{animatedBorderWidth}}px), {{animatedBorderWidth}}px 100%, 100% 100%, 100% 0%, 0% 0%);
   }
   25% {
-    clip-path: polygon(0% 100%, {{borderWidth}}px 100%, {{borderWidth}}px {{borderWidth}}px, calc(100% - {{borderWidth}}px) {{borderWidth}}px, calc(100% - {{borderWidth}}px) calc(100% - {{borderWidth}}px), calc(100% - {{borderWidth}}px) calc(100% - {{borderWidth}}px), calc(100% - {{borderWidth}}px) 100%, 100% 100%, 100% 0%, 0% 0%);
+    clip-path: polygon(0% 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) calc(100% - {{animatedBorderWidth}}px), calc(100% - {{animatedBorderWidth}}px) calc(100% - {{animatedBorderWidth}}px), calc(100% - {{animatedBorderWidth}}px) 100%, 100% 100%, 100% 0%, 0% 0%);
   }
   50% {
-    clip-path: polygon(0% 100%, {{borderWidth}}px 100%, {{borderWidth}}px {{borderWidth}}px, calc(100% - {{borderWidth}}px) {{borderWidth}}px, calc(100% - {{borderWidth}}px) {{borderWidth}}px, calc(100% - {{borderWidth}}px) {{borderWidth}}px, calc(100% - {{borderWidth}}px) {{borderWidth}}px, calc(100% - {{borderWidth}}px) {{borderWidth}}px, 100% 0%, 0% 0%);
+    clip-path: polygon(0% 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) {{animatedBorderWidth}}px, calc(100% - {{animatedBorderWidth}}px) {{animatedBorderWidth}}px, 100% 0%, 0% 0%);
   }
   75% {
-    -webkit-clip-path: polygon(0% 100%, {{borderWidth}}px 100%, {{borderWidth}}px {{borderWidth}}px, {{borderWidth}}px {{borderWidth}}px, {{borderWidth}}px {{borderWidth}}px, {{borderWidth}}px {{borderWidth}}px, {{borderWidth}}px {{borderWidth}}px, {{borderWidth}}px {{borderWidth}}px, {{borderWidth}}px 0%, 0% 0%);
+    -webkit-clip-path: polygon(0% 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px {{animatedBorderWidth}}px, {{animatedBorderWidth}}px {{animatedBorderWidth}}px, {{animatedBorderWidth}}px {{animatedBorderWidth}}px, {{animatedBorderWidth}}px {{animatedBorderWidth}}px, {{animatedBorderWidth}}px {{animatedBorderWidth}}px, {{animatedBorderWidth}}px {{animatedBorderWidth}}px, {{animatedBorderWidth}}px 0%, 0% 0%);
   }
   100% {
-    -webkit-clip-path: polygon(0% 100%, {{borderWidth}}px 100%, {{borderWidth}}px 100%, {{borderWidth}}px 100%, {{borderWidth}}px 100%, {{borderWidth}}px 100%, {{borderWidth}}px 100%, {{borderWidth}}px 100%, {{aborderWidth}}px 100%, 0% 100%);
+    -webkit-clip-path: polygon(0% 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px 100%, {{animatedBorderWidth}}px 100%, 0% 100%);
   }
 }
 

--- a/phasmophobia_evidence_v3/widget.html
+++ b/phasmophobia_evidence_v3/widget.html
@@ -3508,6 +3508,10 @@ m-842 -163 c5 -33 -38 -106 -128 -219 -91 -114 -171 -260 -194 -355 -48 -195
           {{counterDefaultString}}
         </div>
         <div class="counter-theme" id="counter-number">0</div>
+        <div class="counter-theme mr-0.5" id="counter2-name">
+          {{counter2DefaultString}}
+        </div>
+        <div class="counter-theme" id="counter2-number">0</div>
       </div>
     </div>
   </div>

--- a/phasmophobia_evidence_v3/widget.js
+++ b/phasmophobia_evidence_v3/widget.js
@@ -1,4 +1,4 @@
-const version = "3.1";
+const version = "3.1.1";
 
 // Order is important here:
 // EMF-5 | Freezing | Spirit Box | Writing | Orbs | Fingerprints | DOTS
@@ -17,7 +17,7 @@ const BANSHEE = "0000111",
   POLTERGEIST = "0011010",
   REVENANT =    "0101100",
   SHADE =       "1101000",
-  SPIRIT =      "1011000", // ONLY CORRECT ONE
+  SPIRIT =      "1011000",
   WRAITH =      "1010001",
   YOKAI =       "0010101",
   YUREI =       "0100101";
@@ -352,7 +352,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         modOrVIPPermission(config),
         data,
         _setCounterName,
-        [data.text]
+        [1, data.text]
       );
     },
     [fieldData["setCounterNumberCommand"]]: (data) => {
@@ -360,7 +360,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         modOrVIPPermission(config),
         data,
         _setCounterNumber,
-        [data.text]
+        [1, data.text]
       );
     },
     [fieldData["incrementCounterCommand"]]: (data) => {
@@ -368,7 +368,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         modOrVIPPermission(config),
         data,
         _incrementCounter,
-        []
+        [1]
       );
     },
     [fieldData["decrementCounterCommand"]]: (data) => {
@@ -376,7 +376,39 @@ window.addEventListener("onWidgetLoad", function (obj) {
         modOrVIPPermission(config),
         data,
         _decrementCounter,
-        []
+        [1]
+      );
+    },
+    [fieldData["setCounter2NameCommand"]]: (data) => {
+      runCommandWithPermission(
+        modOrVIPPermission(config),
+        data,
+        _setCounterName,
+        [2, data.text]
+      );
+    },
+    [fieldData["setCounter2NumberCommand"]]: (data) => {
+      runCommandWithPermission(
+        modOrVIPPermission(config),
+        data,
+        _setCounterNumber,
+        [2, data.text]
+      );
+    },
+    [fieldData["incrementCounter2Command"]]: (data) => {
+      runCommandWithPermission(
+        modOrVIPPermission(config),
+        data,
+        _incrementCounter,
+        [2]
+      );
+    },
+    [fieldData["decrementCounter2Command"]]: (data) => {
+      runCommandWithPermission(
+        modOrVIPPermission(config),
+        data,
+        _decrementCounter,
+        [2]
       );
     },
     "!glitchedmythos": (data) => {
@@ -548,6 +580,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
   let displayOuija = fieldData["displayOuija"] === "yes" ? true : false;
   let displayEvidence = fieldData["displayEvidence"] === "yes" ? true : false;
   let displayCounter = fieldData["displayCounter"] === "yes" ? true : false;
+  let displayCounter2 = fieldData["displayCounter2"] === "yes" ? true : false;
   let displayOptionalObjectives =
     fieldData["displayOptionalObjectives"] === "yes" ? true : false;
   let displayConclusion =
@@ -586,6 +619,12 @@ window.addEventListener("onWidgetLoad", function (obj) {
 
     if (!displayCounter) {
       $(`#counter-container`).addClass("hidden");
+    }
+    if (!displayCounter2) {
+      $(`#counter2-name`).addClass("hidden");
+      $(`#counter2-number`).addClass("hidden");
+    } else {
+      $(`#counter2-name`).html(". "+$(`#counter2-name`).text());
     }
   }
 
@@ -768,22 +807,22 @@ const _toggleVIPAccessibility = (canUseVIP) => {
   toggleVIPAccessibility(canUseVIP);
 };
 
-const _setCounterName = (command) => {
+const _setCounterName = (num, command) => {
   commandArgument = command.split(" ").slice(1).join(" ");
-  setCounterName(commandArgument);
+  setCounterName(num, commandArgument);
 };
 
-const _setCounterNumber = (command) => {
+const _setCounterNumber = (num, command) => {
   commandArgument = command.split(" ").slice(1).join(" ");
-  setCounterNumber(commandArgument);
+  setCounterNumber(num, commandArgument);
 };
 
-const _incrementCounter = () => {
-  incrementCounter();
+const _incrementCounter = (num) => {
+  incrementCounter(num);
 };
 
-const _decrementCounter = () => {
-  decrementCounter();
+const _decrementCounter = (num) => {
+  decrementCounter(num);
 };
 
 const _glitchedMythos = (command) => {
@@ -1352,25 +1391,43 @@ const updateConclusion = (conclusion) => {
 };
 
 /** COUNTER RELATED DOM MANIPULATING FUNCTIONS */
-const setCounterName = (name) => {
-  $("#counter-name").html(name);
-};
-
-const setCounterNumber = (number) => {
-  let num = parseInt(number);
-
-  if (Number.isInteger(num)) {
-    $("#counter-number").text("" + num);
+const setCounterName = (which, name) => {
+  if (which === 1) {
+    $("#counter-name").html(name);
+  } else if (which === 2) {
+    $("#counter2-name").html(". "+name);
   }
 };
 
-const incrementCounter = (num) => {
-  let counter = $("#counter-number");
+const setCounterNumber = (which, number) => {
+  let num = parseInt(number);
+
+  if (Number.isInteger(num)) {
+    if (which === 1) {
+      $("#counter-number").text("" + num);
+    } else if (which === 2) {
+      $("#counter2-number").text("" + num);
+    }
+  }
+};
+
+const incrementCounter = (which, num) => {
+  let counter;
+  if (which === 1) {
+    counter = $("#counter-number");
+  } else if (which === 2) {
+    counter = $("#counter2-number");
+  }
   counter.text(parseInt(counter.text()) + (num ? num : 1));
 };
 
-const decrementCounter = (num) => {
-  let counter = $("#counter-number");
+const decrementCounter = (which, num) => {
+  let counter;
+  if (which === 1) {
+    counter = $("#counter-number");
+  } else if (which === 2) {
+    counter = $("#counter2-number");
+  }
   counter.text(parseInt(counter.text()) - (num ? num : 1));
 };
 

--- a/phasmophobia_evidence_v3/widget.js
+++ b/phasmophobia_evidence_v3/widget.js
@@ -1,4 +1,4 @@
-const version = "3.1.1";
+const version = "3.4";
 
 // Order is important here:
 // EMF-5 | Freezing | Spirit Box | Writing | Orbs | Fingerprints | DOTS
@@ -106,6 +106,9 @@ const EVIDENCE_NAMES_IN_DOM = [
   "freezing",
   "dots"
 ];
+
+const COUNTER_1 = 1,
+  COUNTER_2 = 2;
 
 // Permission levels for commands
 const PERMISSION_GLITCHED = 0,
@@ -354,7 +357,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         modOrVIPPermission(config),
         data,
         _setCounterName,
-        [1, data.text]
+        [COUNTER_1, data.text]
       );
     },
     [fieldData["setCounterNumberCommand"]]: (data) => {
@@ -362,7 +365,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         modOrVIPPermission(config),
         data,
         _setCounterNumber,
-        [1, data.text]
+        [COUNTER_1, data.text]
       );
     },
     [fieldData["incrementCounterCommand"]]: (data) => {
@@ -370,7 +373,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         modOrVIPPermission(config),
         data,
         _incrementCounter,
-        [1]
+        [COUNTER_1]
       );
     },
     [fieldData["decrementCounterCommand"]]: (data) => {
@@ -378,7 +381,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         modOrVIPPermission(config),
         data,
         _decrementCounter,
-        [1]
+        [COUNTER_1]
       );
     },
     [fieldData["setCounter2NameCommand"]]: (data) => {
@@ -386,7 +389,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         modOrVIPPermission(config),
         data,
         _setCounterName,
-        [2, data.text]
+        [COUNTER_2, data.text]
       );
     },
     [fieldData["setCounter2NumberCommand"]]: (data) => {
@@ -394,7 +397,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         modOrVIPPermission(config),
         data,
         _setCounterNumber,
-        [2, data.text]
+        [COUNTER_2, data.text]
       );
     },
     [fieldData["incrementCounter2Command"]]: (data) => {
@@ -402,7 +405,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         modOrVIPPermission(config),
         data,
         _incrementCounter,
-        [2]
+        [COUNTER_2]
       );
     },
     [fieldData["decrementCounter2Command"]]: (data) => {
@@ -410,7 +413,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         modOrVIPPermission(config),
         data,
         _decrementCounter,
-        [2]
+        [COUNTER_2]
       );
     },
     "!glitchedmythos": (data) => {

--- a/phasmophobia_evidence_v3/widget.js
+++ b/phasmophobia_evidence_v3/widget.js
@@ -119,6 +119,7 @@ let userState = {
   channelName: "",
   conclusionString: "",
   counter: 0,
+  counter2: 0,
   evidence: {
     emf: EVIDENCE_OFF,
     spiritBox: EVIDENCE_OFF,
@@ -195,6 +196,7 @@ const modOrVIPPermission = (configuration) => {
 
 window.addEventListener("onWidgetLoad", function (obj) {
   // Field data from Stream Elements from the overlay settings the user set
+  userState.channelName = obj["detail"]["channel"]["username"];
   const fieldData = obj.detail.fieldData;
 
   // Sets up all the commands for the widget

--- a/phasmophobia_evidence_v3/widget.js
+++ b/phasmophobia_evidence_v3/widget.js
@@ -567,7 +567,9 @@ window.addEventListener("onWidgetLoad", function (obj) {
       : "No Map Selected...",
   };
   config.optionalObj = {
-    noOptionalString: fieldData["noOptionalObjectivesMessage"],
+    noOptionalString: fieldData["noOptionalObjectivesMessage"]
+      ? fieldData["noOptionalObjectivesMessage"]
+      : "Widget Author: GlitchedMythos",
     spacing: fieldData["objectivesSpacing"],
   };
   config.markImpossibleEvidence =

--- a/phasmophobia_evidence_v3/widget.json
+++ b/phasmophobia_evidence_v3/widget.json
@@ -173,28 +173,6 @@
     "value": "!vipoff",
     "group": "Commands"
   },
-  "dashboardBackgroundColor": {
-    "type": "colorpicker",
-    "label": "Background Color",
-    "value": "rgba(0, 0, 0, 0.5)",
-    "group": "Widget Options"
-  },
-  "fontFamily": {
-    "type": "googleFont",
-    "label": "Font",
-    "value": "Roboto",
-    "group": "Widget Options"
-  },
-  "allowVIPS": {
-    "type": "dropdown",
-    "label": "Allow VIPS to use commands",
-    "value": "no",
-    "options": {
-      "yes": "Yes",
-      "no": "No"
-    },
-    "group": "Widget Options"
-  },
   "displayName": {
     "type": "dropdown",
     "label": "Display Name",
@@ -203,7 +181,7 @@
       "yes": "Yes",
       "no": "No"
     },
-    "group": "Name Options"
+    "group": "Optionals"
   },
   "autoCapitalize": {
     "type": "dropdown",
@@ -213,129 +191,7 @@
       "yes": "Yes",
       "no": "No"
     },
-    "group": "Name Options"
-  },
-  "noNameString": {
-    "type": "text",
-    "label": "No Ghost Name Message",
-    "value": "New Ghostie...",
-    "group": "Name Options"
-  },
-  "ghostNameString": {
-    "type": "text",
-    "label": "Ghost Name: [name]",
-    "value": "Name: [name]",
-    "group": "Name Options"
-  },
-  "nameColor": {
-    "type": "colorpicker",
-    "label": "Name Color",
-    "value": "rgb(255, 255, 255)",
-    "group": "Name Options"
-  },
-  "nameFontSize": {
-    "type": "number",
-    "label": "Name Font Size",
-    "value": 24,
-    "group": "Name Options"
-  },
-  "displayLocation": {
-    "type": "dropdown",
-    "label": "Display Map Name",
-    "value": "yes",
-    "options": {
-      "yes": "Yes",
-      "no": "No"
-    },
-    "group": "Map + Bone/Ouija Options"
-  },
-  "displayBoner": {
-    "type": "dropdown",
-    "label": "Display Boner",
-    "value": "yes",
-    "options": {
-      "yes": "Yes",
-      "no": "No"
-    },
-    "group": "Map + Bone/Ouija Options"
-  },
-  "displayOuija": {
-    "type": "dropdown",
-    "label": "Display Ouija",
-    "value": "yes",
-    "options": {
-      "yes": "Yes",
-      "no": "No"
-    },
-    "group": "Map + Bone/Ouija Options"
-  },
-  "noLocationString": {
-    "type": "text",
-    "label": "No Map Message",
-    "value": "No Map Selected...",
-    "group": "Map + Bone/Ouija Options"
-  },
-  "locationFontColor": {
-    "type": "colorpicker",
-    "label": "Map Name Color",
-    "value": "rgb(255, 255, 255)",
-    "group": "Map + Bone/Ouija Options"
-  },
-  "locationFontSize": {
-    "type": "number",
-    "label": "Map Name Font Size",
-    "value": 16,
-    "group": "Map + Bone/Ouija Options"
-  },
-  "locationSpacing": {
-    "type": "dropdown",
-    "label": "Location Spacing Type",
-    "value": "justify-between",
-    "options": {
-      "justify-start": "Left Align",
-      "justify-end": "Right Align",
-      "justify-center": "Center Align",
-      "justify-between": "Space Between",
-      "justify-around": "Space Around",
-      "justify-evenly": "Space Evenly"
-    },
-    "group": "Map + Bone/Ouija Options"
-  },
-  "bonerIconInactiveColor": {
-    "type": "colorpicker",
-    "label": "Boner Inactive Color",
-    "value": "rgba(255, 255, 255, 1)",
-    "group": "Map + Bone/Ouija Options"
-  },
-  "bonerIconActiveColor": {
-    "type": "colorpicker",
-    "label": "Boner Active Color",
-    "value": "rgba(0, 230, 64, 1)",
-    "group": "Map + Bone/Ouija Options"
-  },
-  "bonerIconHeight": {
-    "type": "number",
-    "label": "Boner Icon Height",
-    "value": 30,
-    "group": "Map + Bone/Ouija Options"
-  },
-  "ouijaIconInactiveColor": {
-    "type": "colorpicker",
-    "label": "Ouija Inactive Color",
-    "value": "rgba(255, 255 , 255, 1)",
-    "group": "Map + Bone/Ouija Options"
-  },
-  "ouijaIconActiveColor": {
-    "type": "colorpicker",
-    "label": "Ouija Active Color",
-    "value": "rgba(0, 230, 64, 1)",
-    "group": "Map + Bone/Ouija Options"
-  },
-  "ouijaIconHeight": {
-    "type": "number",
-    "label": "Ouija Icon Height",
-    "value": 30,
-    "group": "Map + Bone/Ouija Options"
+    "group": "Optionals"
   },
   "displayEvidence": {
     "type": "dropdown",
@@ -345,161 +201,37 @@
       "yes": "Yes",
       "no": "No"
     },
-    "group": "Evidence Options"
+    "group": "Optionals"
   },
-  "markImpossibleEvidence": {
+  "displayLocation": {
     "type": "dropdown",
-    "label": "Mark Impossible Evidence",
+    "label": "Display Map Name",
     "value": "yes",
     "options": {
       "yes": "Yes",
       "no": "No"
     },
-    "group": "Evidence Options"
+    "group": "Optionals"
   },
-  "useEvidenceImpossibleCompleted": {
+  "displayBoner": {
     "type": "dropdown",
-    "label": "Different Impossible Color (Complete)",
+    "label": "Display Boner",
     "value": "yes",
     "options": {
       "yes": "Yes",
       "no": "No"
     },
-    "group": "Evidence Options"
+    "group": "Optionals"
   },
-  "evidenceActive": {
-    "type": "colorpicker",
-    "label": "Active Evidence",
-    "value": "rgba(50, 205, 50, 1)",
-    "group": "Evidence Options"
-  },
-  "evidenceInactive": {
-    "type": "colorpicker",
-    "label": "Inactive Evidence",
-    "value": "rgba(255, 255, 255, 1)",
-    "group": "Evidence Options"
-  },
-  "evidenceImpossible": {
-    "type": "colorpicker",
-    "label": "Impossible Evidence",
-    "value": "rgba(234, 66, 29, 0.6)",
-    "group": "Evidence Options"
-  },
-  "evidenceImpossibleCompleted": {
-    "type": "colorpicker",
-    "label": "Impossible Evidence (Complete)",
-    "value": "rgba(28, 69, 233, 0.3)",
-    "group": "Evidence Options"
-  },
-  "evidencePixelSize": {
-    "type": "number",
-    "label": "Evidence Pixel Size",
-    "value": 50,
-    "group": "Evidence Options"
-  },
-  "evidenceMarginSize": {
-    "type": "number",
-    "label": "Evidence Horizontal Margin Size",
-    "value": 5,
-    "group": "Evidence Options"
-  },
-  "displayCounter": {
+  "displayOuija": {
     "type": "dropdown",
-    "label": "Display Counter(s)",
+    "label": "Display Ouija",
     "value": "yes",
     "options": {
       "yes": "Yes",
       "no": "No"
     },
-    "group": "Counter Options"
-  },
-  "displayCounter2": {
-    "type": "dropdown",
-    "label": "Display Second Counter",
-    "value": "yes",
-    "options": {
-      "yes": "Yes",
-      "no": "No"
-    },
-    "group": "Counter Options"
-  },
-  "counterDefaultString": {
-    "type": "text",
-    "label": "Counter Default Name",
-    "value": "Counter:",
-    "group": "Counter Options"
-  },
-  "counter2DefaultString": {
-    "type": "text",
-    "label": "Counter 2 Default Name",
-    "value": "Counter 2:",
-    "group": "Counter Options"
-  },
-  "counterFontColor": {
-    "type": "colorpicker",
-    "label": "Counter Color",
-    "value": "rgb(255, 255, 255)",
-    "group": "Counter Options"
-  },
-  "counterFontSize": {
-    "type": "number",
-    "label": "Counter Font Size",
-    "value": 24,
-    "group": "Counter Options"
-  },
-  "displayOptionalObjectives": {
-    "type": "dropdown",
-    "label": "Display Optional Objectives",
-    "value": "yes",
-    "options": {
-      "yes": "Yes",
-      "no": "No"
-    },
-    "group": "Optional Objective Options"
-  },
-  "noOptionalObjectivesMessage": {
-    "type": "text",
-    "label": "No Optional Objectives Message",
-    "value": "Widget Author: GlitchedMythos",
-    "group": "Optional Objective Options"
-  },
-  "objectivesColor": {
-    "type": "colorpicker",
-    "label": "Objectives Text Color",
-    "value": "rgb(254, 255, 255)",
-    "group": "Optional Objective Options"
-  },
-  "objectivesFontSize": {
-    "type": "number",
-    "label": "Objectives Font Size",
-    "value": 16,
-    "group": "Optional Objective Options"
-  },
-  "objectivesSpacing": {
-    "type": "dropdown",
-    "label": "Objective Spacing Type",
-    "value": "justify-between",
-    "options": {
-      "justify-start": "Left Align",
-      "justify-end": "Right Align",
-      "justify-center": "Center Align",
-      "justify-between": "Space Between",
-      "justify-around": "Space Around",
-      "justify-evenly": "Space Evenly"
-    },
-    "group": "Optional Objective Options"
-  },
-  "objectivesStrikethroughColor": {
-    "type": "colorpicker",
-    "label": "Objectives Strikethrough Color",
-    "value": "rgba(234, 66, 29, 0.83)",
-    "group": "Optional Objective Options"
-  },
-  "objectivesStrikethroughSize": {
-    "type": "number",
-    "label": "Objectives Strikethrough Size",
-    "value": 6,
-    "group": "Optional Objective Options"
+    "group": "Optionals"
   },
   "displayConclusion": {
     "type": "dropdown",
@@ -509,133 +241,115 @@
       "yes": "Yes",
       "no": "No"
     },
-    "group": "Conclusion Options"
+    "group": "Optionals"
+  },
+  "displayCounter": {
+    "type": "dropdown",
+    "label": "Display Counter(s)",
+    "value": "yes",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Optionals"
+  },
+  "displayCounter2": {
+    "type": "dropdown",
+    "label": "Display Counter 2",
+    "value": "yes",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Optionals"
+  },
+  "displayOptionalObjectives": {
+    "type": "dropdown",
+    "label": "Display Optional Objectives",
+    "value": "yes",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Optionals"
+  },
+  "markImpossibleEvidence": {
+    "type": "dropdown",
+    "label": "Mark Impossible Evidence",
+    "value": "yes",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Optionals"
+  },
+  "useEvidenceImpossibleCompleted": {
+    "type": "dropdown",
+    "label": "Use different impossible color when complete:",
+    "value": "yes",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Optionals"
+  },
+  "allowVIPS": {
+    "type": "dropdown",
+    "label": "Allow VIPS to use commands",
+    "value": "no",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Optionals"
+  },
+  "dashboardBackgroundColor": {
+    "type": "colorpicker",
+    "label": "Background Color",
+    "value": "rgba(0, 0, 0, 0.5)",
+    "group": "Theming"
+  },
+  "fontFamily": {
+    "type": "googleFont",
+    "label": "Font",
+    "value": "Roboto",
+    "group": "Theming"
+  },
+  "nameColor": {
+    "type": "colorpicker",
+    "label": "Name Color",
+    "value": "rgb(255, 255, 255)",
+    "group": "Theming"
+  },
+  "nameFontSize": {
+    "type": "number",
+    "label": "Name Font Size",
+    "value": 24,
+    "group": "Theming"
+  },
+  "locationFontColor": {
+    "type": "colorpicker",
+    "label": "Map Name Color",
+    "value": "rgb(255, 255, 255)",
+    "group": "Theming"
+  },
+  "locationFontSize": {
+    "type": "number",
+    "label": "Map Name Font Size",
+    "value": 16,
+    "group": "Theming"
   },
   "conclusionColor": {
     "type": "colorpicker",
     "label": "Conclusion Color",
     "value": "rgb(60, 251, 57)",
-    "group": "Conclusion Options"
+    "group": "Theming"
   },
   "conclusionFontSize": {
     "type": "number",
     "label": "Conclusion Font Size",
     "value": 16,
-    "group": "Conclusion Options"
-  },
-  "zeroEvidenceConclusionString": {
-    "type": "text",
-    "label": "Zero Evidence",
-    "value": "Waiting for Evidence",
-    "group": "Conclusion Messages - Empty For Default"
-  },
-  "oneEvidenceConclusionString": {
-    "type": "text",
-    "label": "One Evidence",
-    "value": "Not sure yet...",
-    "group": "Conclusion Messages - Empty For Default"
-  },
-  "impossibleConclusionString": {
-    "type": "text",
-    "label": "Too Much Evidence",
-    "value": "It's over 9000!!",
-    "group": "Conclusion Messages - Empty For Default"
-  },
-  "bansheeString": {
-    "type": "text",
-    "label": "Banshee",
-    "value": "",
-    "group": "Conclusion Messages - Empty For Default"
-  },
-  "demonString": {
-    "type": "text",
-    "label": "Demon",
-    "value": "",
-    "group": "Conclusion Messages - Empty For Default"
-  },
-  "goryoString": {
-    "type": "text",
-    "label": "Goryo",
-    "value": "",
-    "group": "Conclusion Messages - Empty For Default"
-  },
-  "hantuString": {
-    "type": "text",
-    "label": "Hantu",
-    "value": "",
-    "group": "Conclusion Messages - Empty For Default"
-  },
-  "jinnString": {
-    "type": "text",
-    "label": "Jinn",
-    "value": "",
-    "group": "Conclusion Messages - Empty For Default"
-  },
-  "mareString": {
-    "type": "text",
-    "label": "Mare",
-    "value": "",
-    "group": "Conclusion Messages - Empty For Default"
-  },
-  "mylingString": {
-    "type": "text",
-    "label": "Myling",
-    "value": "",
-    "group": "Conclusion Messages - Empty For Default"
-  },
-  "oniString": {
-    "type": "text",
-    "label": "Oni",
-    "value": "",
-    "group": "Conclusion Messages - Empty For Default"
-  },
-  "phantomString": {
-    "type": "text",
-    "label": "Phantom",
-    "value": "",
-    "group": "Conclusion Messages - Empty For Default"
-  },
-  "poltergeistString": {
-    "type": "text",
-    "label": "Poltergeist",
-    "value": "",
-    "group": "Conclusion Messages - Empty For Default"
-  },
-  "revenantString": {
-    "type": "text",
-    "label": "Revenant",
-    "value": "",
-    "group": "Conclusion Messages - Empty For Default"
-  },
-  "shadeString": {
-    "type": "text",
-    "label": "Shade",
-    "value": "",
-    "group": "Conclusion Messages - Empty For Default"
-  },
-  "spiritString": {
-    "type": "text",
-    "label": "Spirit",
-    "value": "",
-    "group": "Conclusion Messages - Empty For Default"
-  },
-  "wraithString": {
-    "type": "text",
-    "label": "Wraith",
-    "value": "",
-    "group": "Conclusion Messages - Empty For Default"
-  },
-  "yokaiString": {
-    "type": "text",
-    "label": "Yokai",
-    "value": "",
-    "group": "Conclusion Messages - Empty For Default"
-  },
-  "yureiString": {
-    "type": "text",
-    "label": "Yurei",
-    "value": "",
-    "group": "Conclusion Messages - Empty For Default"
+    "group": "Theming"
   },
   "borderColor": {
     "type": "colorpicker",
@@ -645,7 +359,7 @@
   },
   "borderType": {
     "type": "dropdown",
-    "label": "Border Type",
+    "label": "Choose a border type:",
     "value": "solid",
     "options": {
       "solid": "Solid Border",
@@ -658,14 +372,14 @@
   },
   "borderWidth": {
     "type": "number",
-    "label": "Border Width",
+    "label": "Enter a border width:",
     "value": 4,
     "group": "Theming - Border"
   },
   "borderRadius": {
     "type": "number",
-    "label": "Border Radius",
-    "value": 10,
+    "label": "Enter a border radius:",
+    "value": 30,
     "group": "Theming - Border"
   },
   "useGradientBorder": {
@@ -721,6 +435,18 @@
     "value": 0,
     "group": "Theming - Gradient Border"
   },
+  "animatedBorderWidth": {
+    "type": "number",
+    "label": "Enter a border width:",
+    "value": 10,
+    "group": "Theming - Gradient Border"
+  },
+  "animatedBorderRadius": {
+    "type": "number",
+    "label": "Enter a border radius:",
+    "value": 5,
+    "group": "Theming - Gradient Border"
+  },
   "dividerColor": {
     "type": "colorpicker",
     "label": "Divider Color",
@@ -751,5 +477,291 @@
       "divide-y-8": "8px"
     },
     "group": "Theming - Divider"
-  }  
+  },
+  "locationSpacing": {
+    "type": "dropdown",
+    "label": "Choose a spacing type for location bar:",
+    "value": "justify-between",
+    "options": {
+      "justify-start": "Left Align",
+      "justify-end": "Right Align",
+      "justify-center": "Center Align",
+      "justify-between": "Space Between",
+      "justify-around": "Space Around",
+      "justify-evenly": "Space Evenly"
+    },
+    "group": "Theming - Location"
+  },
+  "bonerIconHeight": {
+    "type": "number",
+    "label": "Boner Icon Height",
+    "value": 30,
+    "group": "Theming - Location"
+  },
+  "bonerIconInactiveColor": {
+    "type": "colorpicker",
+    "label": "Boner Inactive Color",
+    "value": "rgba(255, 255, 255, 1)",
+    "group": "Theming - Location"
+  },
+  "bonerIconActiveColor": {
+    "type": "colorpicker",
+    "label": "Boner Active Color",
+    "value": "rgba(0, 230, 64, 1)",
+    "group": "Theming - Location"
+  },
+  "ouijaIconHeight": {
+    "type": "number",
+    "label": "Ouija Icon Height",
+    "value": 30,
+    "group": "Theming - Location"
+  },
+  "ouijaIconInactiveColor": {
+    "type": "colorpicker",
+    "label": "Ouija Inactive Color",
+    "value": "rgba(255, 255 , 255, 1)",
+    "group": "Theming - Location"
+  },
+  "ouijaIconActiveColor": {
+    "type": "colorpicker",
+    "label": "Ouija Active Color",
+    "value": "rgba(0, 230, 64, 1)",
+    "group": "Theming - Location"
+  },
+  "evidenceActive": {
+    "type": "colorpicker",
+    "label": "Active Evidence",
+    "value": "rgba(50,205,50 ,1 )",
+    "group": "Theming - Evidence"
+  },
+  "evidenceInactive": {
+    "type": "colorpicker",
+    "label": "Inactive Evidence",
+    "value": "rgb(255, 255, 255)",
+    "group": "Theming - Evidence"
+  },
+  "evidenceImpossible": {
+    "type": "colorpicker",
+    "label": "Impossible Evidence",
+    "value": "rgba(234, 66, 29, 0.6)",
+    "group": "Theming - Evidence"
+  },
+  "evidenceImpossibleCompleted": {
+    "type": "colorpicker",
+    "label": "Complete Impossible Evidence",
+    "value": "rgba(28, 69, 233, 0.3)",
+    "group": "Theming - Evidence"
+  },
+  "evidencePixelSize": {
+    "type": "number",
+    "label": "Evidence Pixel Size",
+    "value": 50,
+    "group": "Theming - Evidence"
+  },
+  "evidenceMarginSize": {
+    "type": "number",
+    "label": "Evidence Horizontal Margin Size",
+    "value": 5,
+    "group": "Theming - Evidence"
+  },
+  "counterFontColor": {
+    "type": "colorpicker",
+    "label": "Counter Color",
+    "value": "rgb(255, 255, 255)",
+    "group": "Theming - Counter"
+  },
+  "counterFontSize": {
+    "type": "number",
+    "label": "Counter Font Size",
+    "value": 24,
+    "group": "Theming - Counter"
+  },
+  "objectivesColor": {
+    "type": "colorpicker",
+    "label": "Objectives Text Color",
+    "value": "rgb(254, 255, 255)",
+    "group": "Theming - Optional Objectives"
+  },
+  "objectivesFontSize": {
+    "type": "number",
+    "label": "Objectives Font Size",
+    "value": 16,
+    "group": "Theming - Optional Objectives"
+  },
+  "objectivesStrikethroughSize": {
+    "type": "number",
+    "label": "Objectives Strikethrough Size",
+    "value": 6,
+    "group": "Theming - Optional Objectives"
+  },
+  "objectivesStrikethroughColor": {
+    "type": "colorpicker",
+    "label": "Objectives Strikethrough Color",
+    "value": "rgba(234, 66, 29, 0.83)",
+    "group": "Theming - Optional Objectives"
+  },
+  "objectivesSpacing": {
+    "type": "dropdown",
+    "label": "Choose a spacing type for optional objectives:",
+    "value": "justify-between",
+    "options": {
+      "justify-start": "Left Align",
+      "justify-end": "Right Align",
+      "justify-center": "Center Align",
+      "justify-between": "Space Between",
+      "justify-around": "Space Around",
+      "justify-evenly": "Space Evenly"
+    },
+    "group": "Theming - Optional Objectives"
+  },
+  "noNameString": {
+    "type": "text",
+    "label": "No Ghost Name Message",
+    "value": "New Ghostie...",
+    "group": "Name Messages"
+  },
+  "ghostNameString": {
+    "type": "text",
+    "label": "Ghost Name: [name]",
+    "value": "Name: [name]",
+    "group": "Name Messages"
+  },
+  "noLocationString": {
+    "type": "text",
+    "label": "No Map Selected",
+    "value": "No Map Selected...",
+    "group": "Map Messages"
+  },
+  "counterDefaultString": {
+    "type": "text",
+    "label": "Counter Default Name",
+    "value": "Counter:",
+    "group": "Counter"
+  },
+  "counter2DefaultString": {
+    "type": "text",
+    "label": "Counter 2 Default Name",
+    "value": "Counter 2:",
+    "group": "Counter"
+  },
+  "noOptionalObjectivesMessage": {
+    "type": "text",
+    "label": "No Optional Objectives Message",
+    "value": "Widget Author: GlitchedMythos",
+    "group": "Optional Objectives"
+  },
+  "zeroEvidenceConclusionString": {
+    "type": "text",
+    "label": "Zero Evidence",
+    "value": "Waiting for Evidence",
+    "group": "Conclusion Messages"
+  },
+  "oneEvidenceConclusionString": {
+    "type": "text",
+    "label": "One Evidence",
+    "value": "Not sure yet...",
+    "group": "Conclusion Messages"
+  },
+  "impossibleConclusionString": {
+    "type": "text",
+    "label": "Too much evidence entered",
+    "value": "It's over 9000!!",
+    "group": "Conclusion Messages"
+  },
+  "bansheeString": {
+    "type": "text",
+    "label": "Banshee - Leave empty 4 default",
+    "value": "",
+    "group": "Conclusion Messages"
+  },
+  "demonString": {
+    "type": "text",
+    "label": "Demon - Leave empty 4 default",
+    "value": "",
+    "group": "Conclusion Messages"
+  },
+  "goryoString": {
+    "type": "text",
+    "label": "Goryo - Leave empty 4 default",
+    "value": "",
+    "group": "Conclusion Messages"
+  },
+  "hantuString": {
+    "type": "text",
+    "label": "Hantu - Leave empty 4 default",
+    "value": "",
+    "group": "Conclusion Messages"
+  },
+  "jinnString": {
+    "type": "text",
+    "label": "Jinn - Leave empty 4 default",
+    "value": "",
+    "group": "Conclusion Messages"
+  },
+  "mareString": {
+    "type": "text",
+    "label": "Mare - Leave empty 4 default",
+    "value": "",
+    "group": "Conclusion Messages"
+  },
+  "mylingString": {
+    "type": "text",
+    "label": "Myling - Leave empty 4 default",
+    "value": "",
+    "group": "Conclusion Messages"
+  },
+  "oniString": {
+    "type": "text",
+    "label": "Oni - Leave empty 4 default",
+    "value": "",
+    "group": "Conclusion Messages"
+  },
+  "phantomString": {
+    "type": "text",
+    "label": "Phantom - Leave empty 4 default",
+    "value": "",
+    "group": "Conclusion Messages"
+  },
+  "poltergeistString": {
+    "type": "text",
+    "label": "Poltergeist - Leave empty 4 default",
+    "value": "",
+    "group": "Conclusion Messages"
+  },
+  "revenantString": {
+    "type": "text",
+    "label": "Revenant - Leave empty 4 default",
+    "value": "",
+    "group": "Conclusion Messages"
+  },
+  "shadeString": {
+    "type": "text",
+    "label": "Shade - Leave empty 4 default",
+    "value": "",
+    "group": "Conclusion Messages"
+  },
+  "spiritString": {
+    "type": "text",
+    "label": "Spirit - Leave empty 4 default",
+    "value": "",
+    "group": "Conclusion Messages"
+  },
+  "wraithString": {
+    "type": "text",
+    "label": "Wraith - Leave empty 4 default",
+    "value": "",
+    "group": "Conclusion Messages"
+  },
+  "yokaiString": {
+    "type": "text",
+    "label": "Yokai - Leave empty 4 default",
+    "value": "",
+    "group": "Conclusion Messages"
+  },
+  "yureiString": {
+    "type": "text",
+    "label": "Yurei - Leave empty 4 default",
+    "value": "",
+    "group": "Conclusion Messages"
+  }
 }

--- a/phasmophobia_evidence_v3/widget.json
+++ b/phasmophobia_evidence_v3/widget.json
@@ -173,125 +173,17 @@
     "value": "!vipoff",
     "group": "Commands"
   },
-  "displayName": {
-    "type": "dropdown",
-    "label": "Display Name",
-    "value": "yes",
-    "options": {
-      "yes": "Yes",
-      "no": "No"
-    },
-    "group": "Optionals"
+  "dashboardBackgroundColor": {
+    "type": "colorpicker",
+    "label": "Background Color",
+    "value": "rgba(0, 0, 0, 0.5)",
+    "group": "Widget Options"
   },
-  "autoCapitalize": {
-    "type": "dropdown",
-    "label": "Auto Capitalize Name",
-    "value": "yes",
-    "options": {
-      "yes": "Yes",
-      "no": "No"
-    },
-    "group": "Optionals"
-  },
-  "displayEvidence": {
-    "type": "dropdown",
-    "label": "Display Evidence",
-    "value": "yes",
-    "options": {
-      "yes": "Yes",
-      "no": "No"
-    },
-    "group": "Optionals"
-  },
-  "displayLocation": {
-    "type": "dropdown",
-    "label": "Display Map Name",
-    "value": "yes",
-    "options": {
-      "yes": "Yes",
-      "no": "No"
-    },
-    "group": "Optionals"
-  },
-  "displayBoner": {
-    "type": "dropdown",
-    "label": "Display Boner",
-    "value": "yes",
-    "options": {
-      "yes": "Yes",
-      "no": "No"
-    },
-    "group": "Optionals"
-  },
-  "displayOuija": {
-    "type": "dropdown",
-    "label": "Display Ouija",
-    "value": "yes",
-    "options": {
-      "yes": "Yes",
-      "no": "No"
-    },
-    "group": "Optionals"
-  },
-  "displayConclusion": {
-    "type": "dropdown",
-    "label": "Display Conclusion",
-    "value": "yes",
-    "options": {
-      "yes": "Yes",
-      "no": "No"
-    },
-    "group": "Optionals"
-  },
-  "displayCounter": {
-    "type": "dropdown",
-    "label": "Display Counter(s)",
-    "value": "yes",
-    "options": {
-      "yes": "Yes",
-      "no": "No"
-    },
-    "group": "Optionals"
-  },
-  "displayCounter2": {
-    "type": "dropdown",
-    "label": "Display Counter 2",
-    "value": "yes",
-    "options": {
-      "yes": "Yes",
-      "no": "No"
-    },
-    "group": "Optionals"
-  },
-  "displayOptionalObjectives": {
-    "type": "dropdown",
-    "label": "Display Optional Objectives",
-    "value": "yes",
-    "options": {
-      "yes": "Yes",
-      "no": "No"
-    },
-    "group": "Optionals"
-  },
-  "markImpossibleEvidence": {
-    "type": "dropdown",
-    "label": "Mark Impossible Evidence",
-    "value": "yes",
-    "options": {
-      "yes": "Yes",
-      "no": "No"
-    },
-    "group": "Optionals"
-  },
-  "useEvidenceImpossibleCompleted": {
-    "type": "dropdown",
-    "label": "Use different impossible color when complete:",
-    "value": "yes",
-    "options": {
-      "yes": "Yes",
-      "no": "No"
-    },
-    "group": "Optionals"
+  "fontFamily": {
+    "type": "googleFont",
+    "label": "Font",
+    "value": "Roboto",
+    "group": "Widget Options"
   },
   "allowVIPS": {
     "type": "dropdown",
@@ -301,55 +193,449 @@
       "yes": "Yes",
       "no": "No"
     },
-    "group": "Optionals"
+    "group": "Widget Options"
   },
-  "dashboardBackgroundColor": {
-    "type": "colorpicker",
-    "label": "Background Color",
-    "value": "rgba(0, 0, 0, 0.5)",
-    "group": "Theming"
+  "displayName": {
+    "type": "dropdown",
+    "label": "Display Name",
+    "value": "yes",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Name Options"
   },
-  "fontFamily": {
-    "type": "googleFont",
-    "label": "Font",
-    "value": "Roboto",
-    "group": "Theming"
+  "autoCapitalize": {
+    "type": "dropdown",
+    "label": "Auto Capitalize Name",
+    "value": "yes",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Name Options"
+  },
+  "noNameString": {
+    "type": "text",
+    "label": "No Ghost Name Message",
+    "value": "New Ghostie...",
+    "group": "Name Options"
+  },
+  "ghostNameString": {
+    "type": "text",
+    "label": "Ghost Name: [name]",
+    "value": "Name: [name]",
+    "group": "Name Options"
   },
   "nameColor": {
     "type": "colorpicker",
     "label": "Name Color",
     "value": "rgb(255, 255, 255)",
-    "group": "Theming"
+    "group": "Name Options"
   },
   "nameFontSize": {
     "type": "number",
     "label": "Name Font Size",
     "value": 24,
-    "group": "Theming"
+    "group": "Name Options"
+  },
+  "displayLocation": {
+    "type": "dropdown",
+    "label": "Display Map Name",
+    "value": "yes",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Map + Bone/Ouija Options"
+  },
+  "displayBoner": {
+    "type": "dropdown",
+    "label": "Display Boner",
+    "value": "yes",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Map + Bone/Ouija Options"
+  },
+  "displayOuija": {
+    "type": "dropdown",
+    "label": "Display Ouija",
+    "value": "yes",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Map + Bone/Ouija Options"
+  },
+  "noLocationString": {
+    "type": "text",
+    "label": "No Map Message",
+    "value": "No Map Selected...",
+    "group": "Map + Bone/Ouija Options"
   },
   "locationFontColor": {
     "type": "colorpicker",
     "label": "Map Name Color",
     "value": "rgb(255, 255, 255)",
-    "group": "Theming"
+    "group": "Map + Bone/Ouija Options"
   },
   "locationFontSize": {
     "type": "number",
     "label": "Map Name Font Size",
     "value": 16,
-    "group": "Theming"
+    "group": "Map + Bone/Ouija Options"
+  },
+  "locationSpacing": {
+    "type": "dropdown",
+    "label": "Location Spacing Type",
+    "value": "justify-between",
+    "options": {
+      "justify-start": "Left Align",
+      "justify-end": "Right Align",
+      "justify-center": "Center Align",
+      "justify-between": "Space Between",
+      "justify-around": "Space Around",
+      "justify-evenly": "Space Evenly"
+    },
+    "group": "Map + Bone/Ouija Options"
+  },
+  "bonerIconInactiveColor": {
+    "type": "colorpicker",
+    "label": "Boner Inactive Color",
+    "value": "rgba(255, 255, 255, 1)",
+    "group": "Map + Bone/Ouija Options"
+  },
+  "bonerIconActiveColor": {
+    "type": "colorpicker",
+    "label": "Boner Active Color",
+    "value": "rgba(0, 230, 64, 1)",
+    "group": "Map + Bone/Ouija Options"
+  },
+  "bonerIconHeight": {
+    "type": "number",
+    "label": "Boner Icon Height",
+    "value": 30,
+    "group": "Map + Bone/Ouija Options"
+  },
+  "ouijaIconInactiveColor": {
+    "type": "colorpicker",
+    "label": "Ouija Inactive Color",
+    "value": "rgba(255, 255 , 255, 1)",
+    "group": "Map + Bone/Ouija Options"
+  },
+  "ouijaIconActiveColor": {
+    "type": "colorpicker",
+    "label": "Ouija Active Color",
+    "value": "rgba(0, 230, 64, 1)",
+    "group": "Map + Bone/Ouija Options"
+  },
+  "ouijaIconHeight": {
+    "type": "number",
+    "label": "Ouija Icon Height",
+    "value": 30,
+    "group": "Map + Bone/Ouija Options"
+  },
+  "displayEvidence": {
+    "type": "dropdown",
+    "label": "Display Evidence",
+    "value": "yes",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Evidence Options"
+  },
+  "markImpossibleEvidence": {
+    "type": "dropdown",
+    "label": "Mark Impossible Evidence",
+    "value": "yes",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Evidence Options"
+  },
+  "useEvidenceImpossibleCompleted": {
+    "type": "dropdown",
+    "label": "Different Impossible Color (Complete)",
+    "value": "yes",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Evidence Options"
+  },
+  "evidenceActive": {
+    "type": "colorpicker",
+    "label": "Active Evidence",
+    "value": "rgba(50, 205, 50, 1)",
+    "group": "Evidence Options"
+  },
+  "evidenceInactive": {
+    "type": "colorpicker",
+    "label": "Inactive Evidence",
+    "value": "rgba(255, 255, 255, 1)",
+    "group": "Evidence Options"
+  },
+  "evidenceImpossible": {
+    "type": "colorpicker",
+    "label": "Impossible Evidence",
+    "value": "rgba(234, 66, 29, 0.6)",
+    "group": "Evidence Options"
+  },
+  "evidenceImpossibleCompleted": {
+    "type": "colorpicker",
+    "label": "Impossible Evidence (Complete)",
+    "value": "rgba(28, 69, 233, 0.3)",
+    "group": "Evidence Options"
+  },
+  "evidencePixelSize": {
+    "type": "number",
+    "label": "Evidence Pixel Size",
+    "value": 50,
+    "group": "Evidence Options"
+  },
+  "evidenceMarginSize": {
+    "type": "number",
+    "label": "Evidence Horizontal Margin Size",
+    "value": 5,
+    "group": "Evidence Options"
+  },
+  "displayCounter": {
+    "type": "dropdown",
+    "label": "Display Counter(s)",
+    "value": "yes",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Counter Options"
+  },
+  "displayCounter2": {
+    "type": "dropdown",
+    "label": "Display Second Counter",
+    "value": "yes",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Counter Options"
+  },
+  "counterDefaultString": {
+    "type": "text",
+    "label": "Counter Default Name",
+    "value": "Counter:",
+    "group": "Counter Options"
+  },
+  "counter2DefaultString": {
+    "type": "text",
+    "label": "Counter 2 Default Name",
+    "value": "Counter 2:",
+    "group": "Counter Options"
+  },
+  "counterFontColor": {
+    "type": "colorpicker",
+    "label": "Counter Color",
+    "value": "rgb(255, 255, 255)",
+    "group": "Counter Options"
+  },
+  "counterFontSize": {
+    "type": "number",
+    "label": "Counter Font Size",
+    "value": 24,
+    "group": "Counter Options"
+  },
+  "displayOptionalObjectives": {
+    "type": "dropdown",
+    "label": "Display Optional Objectives",
+    "value": "yes",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Optional Objective Options"
+  },
+  "noOptionalObjectivesMessage": {
+    "type": "text",
+    "label": "No Optional Objectives Message",
+    "value": "Widget Author: GlitchedMythos",
+    "group": "Optional Objective Options"
+  },
+  "objectivesColor": {
+    "type": "colorpicker",
+    "label": "Objectives Text Color",
+    "value": "rgb(254, 255, 255)",
+    "group": "Optional Objective Options"
+  },
+  "objectivesFontSize": {
+    "type": "number",
+    "label": "Objectives Font Size",
+    "value": 16,
+    "group": "Optional Objective Options"
+  },
+  "objectivesSpacing": {
+    "type": "dropdown",
+    "label": "Objective Spacing Type",
+    "value": "justify-between",
+    "options": {
+      "justify-start": "Left Align",
+      "justify-end": "Right Align",
+      "justify-center": "Center Align",
+      "justify-between": "Space Between",
+      "justify-around": "Space Around",
+      "justify-evenly": "Space Evenly"
+    },
+    "group": "Optional Objective Options"
+  },
+  "objectivesStrikethroughColor": {
+    "type": "colorpicker",
+    "label": "Objectives Strikethrough Color",
+    "value": "rgba(234, 66, 29, 0.83)",
+    "group": "Optional Objective Options"
+  },
+  "objectivesStrikethroughSize": {
+    "type": "number",
+    "label": "Objectives Strikethrough Size",
+    "value": 6,
+    "group": "Optional Objective Options"
+  },
+  "displayConclusion": {
+    "type": "dropdown",
+    "label": "Display Conclusion",
+    "value": "yes",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Conclusion Options"
   },
   "conclusionColor": {
     "type": "colorpicker",
     "label": "Conclusion Color",
     "value": "rgb(60, 251, 57)",
-    "group": "Theming"
+    "group": "Conclusion Options"
   },
   "conclusionFontSize": {
     "type": "number",
     "label": "Conclusion Font Size",
     "value": 16,
-    "group": "Theming"
+    "group": "Conclusion Options"
+  },
+  "zeroEvidenceConclusionString": {
+    "type": "text",
+    "label": "Zero Evidence",
+    "value": "Waiting for Evidence",
+    "group": "Conclusion Messages - Empty For Default"
+  },
+  "oneEvidenceConclusionString": {
+    "type": "text",
+    "label": "One Evidence",
+    "value": "Not sure yet...",
+    "group": "Conclusion Messages - Empty For Default"
+  },
+  "impossibleConclusionString": {
+    "type": "text",
+    "label": "Too Much Evidence",
+    "value": "It's over 9000!!",
+    "group": "Conclusion Messages - Empty For Default"
+  },
+  "bansheeString": {
+    "type": "text",
+    "label": "Banshee",
+    "value": "",
+    "group": "Conclusion Messages - Empty For Default"
+  },
+  "demonString": {
+    "type": "text",
+    "label": "Demon",
+    "value": "",
+    "group": "Conclusion Messages - Empty For Default"
+  },
+  "goryoString": {
+    "type": "text",
+    "label": "Goryo",
+    "value": "",
+    "group": "Conclusion Messages - Empty For Default"
+  },
+  "hantuString": {
+    "type": "text",
+    "label": "Hantu",
+    "value": "",
+    "group": "Conclusion Messages - Empty For Default"
+  },
+  "jinnString": {
+    "type": "text",
+    "label": "Jinn",
+    "value": "",
+    "group": "Conclusion Messages - Empty For Default"
+  },
+  "mareString": {
+    "type": "text",
+    "label": "Mare",
+    "value": "",
+    "group": "Conclusion Messages - Empty For Default"
+  },
+  "mylingString": {
+    "type": "text",
+    "label": "Myling",
+    "value": "",
+    "group": "Conclusion Messages - Empty For Default"
+  },
+  "oniString": {
+    "type": "text",
+    "label": "Oni",
+    "value": "",
+    "group": "Conclusion Messages - Empty For Default"
+  },
+  "phantomString": {
+    "type": "text",
+    "label": "Phantom",
+    "value": "",
+    "group": "Conclusion Messages - Empty For Default"
+  },
+  "poltergeistString": {
+    "type": "text",
+    "label": "Poltergeist",
+    "value": "",
+    "group": "Conclusion Messages - Empty For Default"
+  },
+  "revenantString": {
+    "type": "text",
+    "label": "Revenant",
+    "value": "",
+    "group": "Conclusion Messages - Empty For Default"
+  },
+  "shadeString": {
+    "type": "text",
+    "label": "Shade",
+    "value": "",
+    "group": "Conclusion Messages - Empty For Default"
+  },
+  "spiritString": {
+    "type": "text",
+    "label": "Spirit",
+    "value": "",
+    "group": "Conclusion Messages - Empty For Default"
+  },
+  "wraithString": {
+    "type": "text",
+    "label": "Wraith",
+    "value": "",
+    "group": "Conclusion Messages - Empty For Default"
+  },
+  "yokaiString": {
+    "type": "text",
+    "label": "Yokai",
+    "value": "",
+    "group": "Conclusion Messages - Empty For Default"
+  },
+  "yureiString": {
+    "type": "text",
+    "label": "Yurei",
+    "value": "",
+    "group": "Conclusion Messages - Empty For Default"
   },
   "borderColor": {
     "type": "colorpicker",
@@ -359,7 +645,7 @@
   },
   "borderType": {
     "type": "dropdown",
-    "label": "Choose a border type:",
+    "label": "Border Type",
     "value": "solid",
     "options": {
       "solid": "Solid Border",
@@ -372,14 +658,14 @@
   },
   "borderWidth": {
     "type": "number",
-    "label": "Enter a border width:",
+    "label": "Border Width",
     "value": 4,
     "group": "Theming - Border"
   },
   "borderRadius": {
     "type": "number",
-    "label": "Enter a border radius:",
-    "value": 30,
+    "label": "Border Radius",
+    "value": 10,
     "group": "Theming - Border"
   },
   "useGradientBorder": {
@@ -435,18 +721,6 @@
     "value": 0,
     "group": "Theming - Gradient Border"
   },
-  "animatedBorderWidth": {
-    "type": "number",
-    "label": "Enter a border width:",
-    "value": 10,
-    "group": "Theming - Gradient Border"
-  },
-  "animatedBorderRadius": {
-    "type": "number",
-    "label": "Enter a border radius:",
-    "value": 5,
-    "group": "Theming - Gradient Border"
-  },
   "dividerColor": {
     "type": "colorpicker",
     "label": "Divider Color",
@@ -477,291 +751,5 @@
       "divide-y-8": "8px"
     },
     "group": "Theming - Divider"
-  },
-  "locationSpacing": {
-    "type": "dropdown",
-    "label": "Choose a spacing type for location bar:",
-    "value": "justify-between",
-    "options": {
-      "justify-start": "Left Align",
-      "justify-end": "Right Align",
-      "justify-center": "Center Align",
-      "justify-between": "Space Between",
-      "justify-around": "Space Around",
-      "justify-evenly": "Space Evenly"
-    },
-    "group": "Theming - Location"
-  },
-  "bonerIconHeight": {
-    "type": "number",
-    "label": "Boner Icon Height",
-    "value": 30,
-    "group": "Theming - Location"
-  },
-  "bonerIconInactiveColor": {
-    "type": "colorpicker",
-    "label": "Boner Inactive Color",
-    "value": "rgba(255, 255, 255, 1)",
-    "group": "Theming - Location"
-  },
-  "bonerIconActiveColor": {
-    "type": "colorpicker",
-    "label": "Boner Active Color",
-    "value": "rgba(0, 230, 64, 1)",
-    "group": "Theming - Location"
-  },
-  "ouijaIconHeight": {
-    "type": "number",
-    "label": "Ouija Icon Height",
-    "value": 30,
-    "group": "Theming - Location"
-  },
-  "ouijaIconInactiveColor": {
-    "type": "colorpicker",
-    "label": "Ouija Inactive Color",
-    "value": "rgba(255, 255 , 255, 1)",
-    "group": "Theming - Location"
-  },
-  "ouijaIconActiveColor": {
-    "type": "colorpicker",
-    "label": "Ouija Active Color",
-    "value": "rgba(0, 230, 64, 1)",
-    "group": "Theming - Location"
-  },
-  "evidenceActive": {
-    "type": "colorpicker",
-    "label": "Active Evidence",
-    "value": "rgba(50,205,50 ,1 )",
-    "group": "Theming - Evidence"
-  },
-  "evidenceInactive": {
-    "type": "colorpicker",
-    "label": "Inactive Evidence",
-    "value": "rgb(255, 255, 255)",
-    "group": "Theming - Evidence"
-  },
-  "evidenceImpossible": {
-    "type": "colorpicker",
-    "label": "Impossible Evidence",
-    "value": "rgba(234, 66, 29, 0.6)",
-    "group": "Theming - Evidence"
-  },
-  "evidenceImpossibleCompleted": {
-    "type": "colorpicker",
-    "label": "Complete Impossible Evidence",
-    "value": "rgba(28, 69, 233, 0.3)",
-    "group": "Theming - Evidence"
-  },
-  "evidencePixelSize": {
-    "type": "number",
-    "label": "Evidence Pixel Size",
-    "value": 50,
-    "group": "Theming - Evidence"
-  },
-  "evidenceMarginSize": {
-    "type": "number",
-    "label": "Evidence Horizontal Margin Size",
-    "value": 5,
-    "group": "Theming - Evidence"
-  },
-  "counterFontColor": {
-    "type": "colorpicker",
-    "label": "Counter Color",
-    "value": "rgb(255, 255, 255)",
-    "group": "Theming - Counter"
-  },
-  "counterFontSize": {
-    "type": "number",
-    "label": "Counter Font Size",
-    "value": 24,
-    "group": "Theming - Counter"
-  },
-  "objectivesColor": {
-    "type": "colorpicker",
-    "label": "Objectives Text Color",
-    "value": "rgb(254, 255, 255)",
-    "group": "Theming - Optional Objectives"
-  },
-  "objectivesFontSize": {
-    "type": "number",
-    "label": "Objectives Font Size",
-    "value": 16,
-    "group": "Theming - Optional Objectives"
-  },
-  "objectivesStrikethroughSize": {
-    "type": "number",
-    "label": "Objectives Strikethrough Size",
-    "value": 6,
-    "group": "Theming - Optional Objectives"
-  },
-  "objectivesStrikethroughColor": {
-    "type": "colorpicker",
-    "label": "Objectives Strikethrough Color",
-    "value": "rgba(234, 66, 29, 0.83)",
-    "group": "Theming - Optional Objectives"
-  },
-  "objectivesSpacing": {
-    "type": "dropdown",
-    "label": "Choose a spacing type for optional objectives:",
-    "value": "justify-between",
-    "options": {
-      "justify-start": "Left Align",
-      "justify-end": "Right Align",
-      "justify-center": "Center Align",
-      "justify-between": "Space Between",
-      "justify-around": "Space Around",
-      "justify-evenly": "Space Evenly"
-    },
-    "group": "Theming - Optional Objectives"
-  },
-  "noNameString": {
-    "type": "text",
-    "label": "No Ghost Name Message",
-    "value": "New Ghostie...",
-    "group": "Name Messages"
-  },
-  "ghostNameString": {
-    "type": "text",
-    "label": "Ghost Name: [name]",
-    "value": "Name: [name]",
-    "group": "Name Messages"
-  },
-  "noLocationString": {
-    "type": "text",
-    "label": "No Map Selected",
-    "value": "No Map Selected...",
-    "group": "Map Messages"
-  },
-  "counterDefaultString": {
-    "type": "text",
-    "label": "Counter Default Name",
-    "value": "Counter:",
-    "group": "Counter"
-  },
-  "counter2DefaultString": {
-    "type": "text",
-    "label": "Counter 2 Default Name",
-    "value": "Counter 2:",
-    "group": "Counter"
-  },
-  "noOptionalObjectivesMessage": {
-    "type": "text",
-    "label": "No Optional Objectives Message",
-    "value": "Widget Author: GlitchedMythos",
-    "group": "Optional Objectives"
-  },
-  "zeroEvidenceConclusionString": {
-    "type": "text",
-    "label": "Zero Evidence",
-    "value": "Waiting for Evidence",
-    "group": "Conclusion Messages"
-  },
-  "oneEvidenceConclusionString": {
-    "type": "text",
-    "label": "One Evidence",
-    "value": "Not sure yet...",
-    "group": "Conclusion Messages"
-  },
-  "impossibleConclusionString": {
-    "type": "text",
-    "label": "Too much evidence entered",
-    "value": "It's over 9000!!",
-    "group": "Conclusion Messages"
-  },
-  "bansheeString": {
-    "type": "text",
-    "label": "Banshee - Leave empty 4 default",
-    "value": "",
-    "group": "Conclusion Messages"
-  },
-  "demonString": {
-    "type": "text",
-    "label": "Demon - Leave empty 4 default",
-    "value": "",
-    "group": "Conclusion Messages"
-  },
-  "goryoString": {
-    "type": "text",
-    "label": "Goryo - Leave empty 4 default",
-    "value": "",
-    "group": "Conclusion Messages"
-  },
-  "hantuString": {
-    "type": "text",
-    "label": "Hantu - Leave empty 4 default",
-    "value": "",
-    "group": "Conclusion Messages"
-  },
-  "jinnString": {
-    "type": "text",
-    "label": "Jinn - Leave empty 4 default",
-    "value": "",
-    "group": "Conclusion Messages"
-  },
-  "mareString": {
-    "type": "text",
-    "label": "Mare - Leave empty 4 default",
-    "value": "",
-    "group": "Conclusion Messages"
-  },
-  "mylingString": {
-    "type": "text",
-    "label": "Myling - Leave empty 4 default",
-    "value": "",
-    "group": "Conclusion Messages"
-  },
-  "oniString": {
-    "type": "text",
-    "label": "Oni - Leave empty 4 default",
-    "value": "",
-    "group": "Conclusion Messages"
-  },
-  "phantomString": {
-    "type": "text",
-    "label": "Phantom - Leave empty 4 default",
-    "value": "",
-    "group": "Conclusion Messages"
-  },
-  "poltergeistString": {
-    "type": "text",
-    "label": "Poltergeist - Leave empty 4 default",
-    "value": "",
-    "group": "Conclusion Messages"
-  },
-  "revenantString": {
-    "type": "text",
-    "label": "Revenant - Leave empty 4 default",
-    "value": "",
-    "group": "Conclusion Messages"
-  },
-  "shadeString": {
-    "type": "text",
-    "label": "Shade - Leave empty 4 default",
-    "value": "",
-    "group": "Conclusion Messages"
-  },
-  "spiritString": {
-    "type": "text",
-    "label": "Spirit - Leave empty 4 default",
-    "value": "",
-    "group": "Conclusion Messages"
-  },
-  "wraithString": {
-    "type": "text",
-    "label": "Wraith - Leave empty 4 default",
-    "value": "",
-    "group": "Conclusion Messages"
-  },
-  "yokaiString": {
-    "type": "text",
-    "label": "Yokai - Leave empty 4 default",
-    "value": "",
-    "group": "Conclusion Messages"
-  },
-  "yureiString": {
-    "type": "text",
-    "label": "Yurei - Leave empty 4 default",
-    "value": "",
-    "group": "Conclusion Messages"
-  }
+  }  
 }

--- a/phasmophobia_evidence_v3/widget.json
+++ b/phasmophobia_evidence_v3/widget.json
@@ -115,26 +115,50 @@
   },
   "setCounterNameCommand": {
     "type": "string",
-    "label": "Set Counter Name Command",
+    "label": "Set Counter 1 Name Command",
     "value": "!setcounter",
     "group": "Commands"
   },
   "setCounterNumberCommand": {
     "type": "string",
-    "label": "Set Counter Number Command",
+    "label": "Set Counter 1 Number Command",
     "value": "!setcounternumber",
     "group": "Commands"
   },
   "incrementCounterCommand": {
     "type": "string",
-    "label": "Increment Counter Command",
+    "label": "Increment Counter 1 Command",
     "value": "!counterup",
     "group": "Commands"
   },
   "decrementCounterCommand": {
     "type": "string",
-    "label": "Decrement Counter Command",
+    "label": "Decrement Counter 1 Command",
     "value": "!counterdown",
+    "group": "Commands"
+  },
+  "setCounter2NameCommand": {
+    "type": "string",
+    "label": "Set Counter 2 Name Command",
+    "value": "!setcounter2",
+    "group": "Commands"
+  },
+  "setCounter2NumberCommand": {
+    "type": "string",
+    "label": "Set Counter 2 Number Command",
+    "value": "!setcounter2number",
+    "group": "Commands"
+  },
+  "incrementCounter2Command": {
+    "type": "string",
+    "label": "Increment Counter 2 Command",
+    "value": "!counter2up",
+    "group": "Commands"
+  },
+  "decrementCounter2Command": {
+    "type": "string",
+    "label": "Decrement Counter 2 Command",
+    "value": "!counter2down",
     "group": "Commands"
   },
   "vipToggleOnCommand": {
@@ -221,7 +245,17 @@
   },
   "displayCounter": {
     "type": "dropdown",
-    "label": "Display Counter",
+    "label": "Display Counter(s)",
+    "value": "yes",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Optionals"
+  },
+  "displayCounter2": {
+    "type": "dropdown",
+    "label": "Display Counter 2",
     "value": "yes",
     "options": {
       "yes": "Yes",
@@ -290,7 +324,7 @@
   "nameFontSize": {
     "type": "number",
     "label": "Name Font Size",
-    "value": "24",
+    "value": 24,
     "group": "Theming"
   },
   "locationFontColor": {
@@ -302,7 +336,7 @@
   "locationFontSize": {
     "type": "number",
     "label": "Map Name Font Size",
-    "value": "16",
+    "value": 16,
     "group": "Theming"
   },
   "conclusionColor": {
@@ -314,7 +348,7 @@
   "conclusionFontSize": {
     "type": "number",
     "label": "Conclusion Font Size",
-    "value": "16",
+    "value": 16,
     "group": "Theming"
   },
   "borderColor": {
@@ -371,9 +405,9 @@
   "animationDuration": {
     "type": "slider",
     "label": "Animate Duration (sec)",
-    "value": "4",
-    "min": "1",
-    "max": "10",
+    "value": 4,
+    "min": 1,
+    "max": 10,
     "step": 0.5,
     "group": "Theming - Gradient Border"
   },
@@ -461,7 +495,7 @@
   "bonerIconHeight": {
     "type": "number",
     "label": "Boner Icon Height",
-    "value": "30",
+    "value": 30,
     "group": "Theming - Location"
   },
   "bonerIconInactiveColor": {
@@ -479,7 +513,7 @@
   "ouijaIconHeight": {
     "type": "number",
     "label": "Ouija Icon Height",
-    "value": "30",
+    "value": 30,
     "group": "Theming - Location"
   },
   "ouijaIconInactiveColor": {
@@ -551,13 +585,13 @@
   "objectivesFontSize": {
     "type": "number",
     "label": "Objectives Font Size",
-    "value": "16",
+    "value": 16,
     "group": "Theming - Optional Objectives"
   },
   "objectivesStrikethroughSize": {
     "type": "number",
     "label": "Objectives Strikethrough Size",
-    "value": "6",
+    "value": 6,
     "group": "Theming - Optional Objectives"
   },
   "objectivesStrikethroughColor": {
@@ -602,6 +636,12 @@
     "type": "text",
     "label": "Counter Default Name",
     "value": "Counter:",
+    "group": "Counter"
+  },
+  "counter2DefaultString": {
+    "type": "text",
+    "label": "Counter 2 Default Name",
+    "value": "Counter 2:",
     "group": "Counter"
   },
   "noOptionalObjectivesMessage": {


### PR DESCRIPTION
Updated the Widget to allow for up to two counters.
Minor Fixes
Increased Version to 3.4

~~Removed some Animated Border settings and consolidated with the Standard Border settings.
Refactored the json file to consolidate and move around the options to try to make it easier to use.
**Note**: to remove these two changes, view the fork from [0acf26a](https://github.com/TheSquall/se-widgets/tree/0acf26ab04fbe8c7f73cd0cadb714e425c4b1ccc/phasmophobia_evidence_v3)~~
This will be handled as a separate Pull Request.