### PR TITLE
Add option for multiple command names, add option for allowing all viewers to update

### DIFF
--- a/phasmophobia_evidence_v3/widget.js
+++ b/phasmophobia_evidence_v3/widget.js
@@ -436,7 +436,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
   }
 
   // Configuration based on user choices
-  config.allowVIPS = fieldData["allowVIPS"] === "yes" ? true : false;
+  config.allowVIPS = fieldData["allowVIPS"] === "yes";
   config.conclusionStrings = {
     zeroEvidenceConclusionString: fieldData["zeroEvidenceConclusionString"]
       ? fieldData["zeroEvidenceConclusionString"]

--- a/phasmophobia_evidence_v3/widget.js
+++ b/phasmophobia_evidence_v3/widget.js
@@ -195,7 +195,7 @@ const hasPermission = (permission, userLevel) => {
 
 // For commands where VIP's are allowed to help
 const modOrVIPPermission = (configuration) => {
-  return configuration.allowVIPS ? PERMISSION_VIP : PERMISSION_MOD;
+  return configuration.allowAll ? PERMISSION_ALL : configuration.allowVIPS ? PERMISSION_VIP : PERMISSION_MOD;
 };
 
 window.addEventListener("onWidgetLoad", function (obj) {
@@ -436,6 +436,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
   }
 
   // Configuration based on user choices
+  config.allowAll = fieldData["allowAll"] === "yes";
   config.allowVIPS = fieldData["allowVIPS"] === "yes";
   config.conclusionStrings = {
     zeroEvidenceConclusionString: fieldData["zeroEvidenceConclusionString"]

--- a/phasmophobia_evidence_v3/widget.js
+++ b/phasmophobia_evidence_v3/widget.js
@@ -343,6 +343,22 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [2, userState] // The position in array
       );
     },
+    "allToggleOnCommand": (data) => {
+      runCommandWithPermission(
+        PERMISSION_MOD,
+        data,
+        _toggleAllAccessibility,
+        [true]
+      );
+    },
+    "allToggleOffCommand": (data) => {
+      runCommandWithPermission(
+        PERMISSION_MOD,
+        data,
+        _toggleAllAccessibility,
+        [false]
+      );
+    },
     "vipToggleOnCommand": (data) => {
       runCommandWithPermission(PERMISSION_MOD, data, _toggleVIPAccessibility, [
         true,
@@ -823,6 +839,10 @@ const _toggleOptionalObjective = (objectiveNumber, state) => {
   toggleStrikethrough(objectiveNumber, state);
 };
 
+const _toggleAllAccessibility = (canUseAll) => {
+  toggleAllAccessibility(canUseAll);
+};
+
 const _toggleVIPAccessibility = (canUseVIP) => {
   toggleVIPAccessibility(canUseVIP);
 };
@@ -1132,6 +1152,14 @@ const camelCase = (sentence) => {
   return sentence.replace(/(^\w{1})|(\s+\w{1})/g, (letter) =>
     letter.toUpperCase()
   );
+};
+
+const toggleAllAccessibility = (canUseAll) => {
+  if (canUseAll !== undefined && canUseAll !== null) {
+    config.allowAll = canUseAll;
+  } else {
+    config.allowAll = !config.allowAll;
+  }
 };
 
 const toggleVIPAccessibility = (canUseVIP) => {

--- a/phasmophobia_evidence_v3/widget.js
+++ b/phasmophobia_evidence_v3/widget.js
@@ -114,7 +114,8 @@ const COUNTER_1 = 1,
 const PERMISSION_GLITCHED = 0,
   PERMISSION_BROADCASTER = 1,
   PERMISSION_MOD = 2,
-  PERMISSION_VIP = 3;
+  PERMISSION_VIP = 3,
+  PERMISSION_ALL = 999;
 
 // TODO: Move all widget and user state to here
 let userState = {
@@ -166,9 +167,9 @@ const runCommandWithPermission = (permission, data, command, commandArgs) => {
 };
 
 const getUserLevelFromData = (data) => {
-  let level = 999;
+  let level = PERMISSION_ALL;
   let badges = data.badges;
-  let badgeLevel = 999;
+  let badgeLevel = PERMISSION_ALL;
 
   for (let i = 0; i < badges.length; i++) {
     if (data.displayName.toLowerCase() === "glitchedmythos") {

--- a/phasmophobia_evidence_v3/widget.js
+++ b/phasmophobia_evidence_v3/widget.js
@@ -194,7 +194,7 @@ const hasPermission = (permission, userLevel) => {
 };
 
 // For commands where VIP's are allowed to help
-const modOrVIPPermission = (configuration) => {
+const getRequiredPermissionLevel = (configuration) => {
   return configuration.allowAll ? PERMISSION_ALL : configuration.allowVIPS ? PERMISSION_VIP : PERMISSION_MOD;
 };
 
@@ -206,14 +206,16 @@ window.addEventListener("onWidgetLoad", function (obj) {
   // Declare lambdas (arrow functions) for each command key
   const commands = {
     "resetCommand": (data) => {
-      runCommandWithPermission(modOrVIPPermission(config), data, _resetGhost, [
-        data.text,
-        userState,
-      ]);
+      runCommandWithPermission(
+        getRequiredPermissionLevel(config),
+        data,
+        _resetGhost,
+        [data.text, userState]
+      );
     },
     "nameCommand": (data) => {
       runCommandWithPermission(
-        modOrVIPPermission(config),
+        getRequiredPermissionLevel(config),
         data,
         _setGhostName,
         [data.text, userState]
@@ -221,7 +223,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
     },
     "firstnameCommand": (data) => {
       runCommandWithPermission(
-        modOrVIPPermission(config),
+        getRequiredPermissionLevel(config),
         data,
         _setGhostFirstName,
         [data.text, userState]
@@ -229,7 +231,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
     },
     "surnameCommand": (data) => {
       runCommandWithPermission(
-        modOrVIPPermission(config),
+        getRequiredPermissionLevel(config),
         data,
         _setGhostSurName,
         [data.text, userState]
@@ -237,37 +239,47 @@ window.addEventListener("onWidgetLoad", function (obj) {
     },
     "locationNameCommand": (data) => {
       runCommandWithPermission(
-        modOrVIPPermission(config),
+        getRequiredPermissionLevel(config),
         data,
         _setLocationName,
         [data.text, userState]
       );
     },
     "locationDiffCommand": (data) => {
-      runCommandWithPermission(modOrVIPPermission(config), data, _setDiffName, [
-        data.text,
-        userState,
-      ]);
+      runCommandWithPermission(
+        getRequiredPermissionLevel(config),
+        data,
+        _setDiffName,
+        [data.text, userState]
+      );
     },
     "bonerCommand": (data) => {
-      runCommandWithPermission(modOrVIPPermission(config), data, _toggleBoner, [
-        userState,
-      ]);
+      runCommandWithPermission(
+        getRequiredPermissionLevel(config),
+        data,
+        _toggleBoner,
+        [userState]
+      );
     },
     "ouijaCommand": (data) => {
-      runCommandWithPermission(modOrVIPPermission(config), data, _toggleOuija, [
-        userState,
-      ]);
+      runCommandWithPermission(
+        getRequiredPermissionLevel(config),
+        data,
+        _toggleOuija,
+        [userState]
+      );
     },
     "emfCommand": (data) => {
-      runCommandWithPermission(modOrVIPPermission(config), data, _toggleEMF, [
-        userState,
-        config,
-      ]);
+      runCommandWithPermission(
+        getRequiredPermissionLevel(config),
+        data,
+        _toggleEMF,
+        [userState, config]
+      );
     },
     "spiritBoxCommand": (data) => {
       runCommandWithPermission(
-        modOrVIPPermission(config),
+        getRequiredPermissionLevel(config),
         data,
         _toggleSpiritBox,
         [userState, config]
@@ -275,21 +287,23 @@ window.addEventListener("onWidgetLoad", function (obj) {
     },
     "fingerprintsCommand": (data) => {
       runCommandWithPermission(
-        modOrVIPPermission(config),
+        getRequiredPermissionLevel(config),
         data,
         _toggleFingerprints,
         [userState, config]
       );
     },
     "orbsCommand": (data) => {
-      runCommandWithPermission(modOrVIPPermission(config), data, _toggleOrbs, [
-        userState,
-        config,
-      ]);
+      runCommandWithPermission(
+        getRequiredPermissionLevel(config),
+        data,
+        _toggleOrbs,
+        [userState, config]
+      );
     },
     "writingCommand": (data) => {
       runCommandWithPermission(
-        modOrVIPPermission(config),
+        getRequiredPermissionLevel(config),
         data,
         _toggleWriting,
         [userState, config]
@@ -297,7 +311,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
     },
     "freezingCommand": (data) => {
       runCommandWithPermission(
-        modOrVIPPermission(config),
+        getRequiredPermissionLevel(config),
         data,
         _toggleFreezing,
         [userState, config]
@@ -305,7 +319,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
     },
     "dotsCommand": (data) => {
       runCommandWithPermission(
-        modOrVIPPermission(config),
+        getRequiredPermissionLevel(config),
         data,
         _toggleDots,
         [userState, config]
@@ -313,7 +327,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
     },
     "optionalObjectivesCommand": (data) => {
       runCommandWithPermission(
-        modOrVIPPermission(config),
+        getRequiredPermissionLevel(config),
         data,
         _setOptionalObjectives,
         [data.text, userState]
@@ -321,7 +335,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
     },
     "toggleOptObjOneCommand": (data) => {
       runCommandWithPermission(
-        modOrVIPPermission(config),
+        getRequiredPermissionLevel(config),
         data,
         _toggleOptionalObjective,
         [0, userState] // The position in array
@@ -329,7 +343,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
     },
     "toggleOptObjTwoCommand": (data) => {
       runCommandWithPermission(
-        modOrVIPPermission(config),
+        getRequiredPermissionLevel(config),
         data,
         _toggleOptionalObjective,
         [1, userState] // The position in array
@@ -337,7 +351,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
     },
     "toggleOptObjThreeCommand": (data) => {
       runCommandWithPermission(
-        modOrVIPPermission(config),
+        getRequiredPermissionLevel(config),
         data,
         _toggleOptionalObjective,
         [2, userState] // The position in array
@@ -360,18 +374,24 @@ window.addEventListener("onWidgetLoad", function (obj) {
       );
     },
     "vipToggleOnCommand": (data) => {
-      runCommandWithPermission(PERMISSION_MOD, data, _toggleVIPAccessibility, [
-        true,
-      ]);
+      runCommandWithPermission(
+        PERMISSION_MOD,
+        data,
+        _toggleVIPAccessibility,
+        [true]
+      );
     },
     "vipToggleOffCommand": (data) => {
-      runCommandWithPermission(PERMISSION_MOD, data, _toggleVIPAccessibility, [
-        false,
-      ]);
+      runCommandWithPermission(
+        PERMISSION_MOD,
+        data,
+        _toggleVIPAccessibility,
+        [false]
+      );
     },
     "setCounterNameCommand": (data) => {
       runCommandWithPermission(
-        modOrVIPPermission(config),
+        getRequiredPermissionLevel(config),
         data,
         _setCounterName,
         [COUNTER_1, data.text]
@@ -379,7 +399,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
     },
     "setCounterNumberCommand": (data) => {
       runCommandWithPermission(
-        modOrVIPPermission(config),
+        getRequiredPermissionLevel(config),
         data,
         _setCounterNumber,
         [COUNTER_1, data.text]
@@ -387,7 +407,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
     },
     "incrementCounterCommand": (data) => {
       runCommandWithPermission(
-        modOrVIPPermission(config),
+        getRequiredPermissionLevel(config),
         data,
         _incrementCounter,
         [COUNTER_1]
@@ -395,7 +415,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
     },
     "decrementCounterCommand": (data) => {
       runCommandWithPermission(
-        modOrVIPPermission(config),
+        getRequiredPermissionLevel(config),
         data,
         _decrementCounter,
         [COUNTER_1]
@@ -403,7 +423,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
     },
     "setCounter2NameCommand": (data) => {
       runCommandWithPermission(
-        modOrVIPPermission(config),
+        getRequiredPermissionLevel(config),
         data,
         _setCounterName,
         [COUNTER_2, data.text]
@@ -411,7 +431,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
     },
     "setCounter2NumberCommand": (data) => {
       runCommandWithPermission(
-        modOrVIPPermission(config),
+        getRequiredPermissionLevel(config),
         data,
         _setCounterNumber,
         [COUNTER_2, data.text]
@@ -419,7 +439,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
     },
     "incrementCounter2Command": (data) => {
       runCommandWithPermission(
-        modOrVIPPermission(config),
+        getRequiredPermissionLevel(config),
         data,
         _incrementCounter,
         [COUNTER_2]
@@ -427,7 +447,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
     },
     "decrementCounter2Command": (data) => {
       runCommandWithPermission(
-        modOrVIPPermission(config),
+        getRequiredPermissionLevel(config),
         data,
         _decrementCounter,
         [COUNTER_2]
@@ -438,9 +458,12 @@ window.addEventListener("onWidgetLoad", function (obj) {
   // Sets up all the commands for the widget
   config.commands = {
     "!glitchedmythos": (data) => {
-      runCommandWithPermission(PERMISSION_GLITCHED, data, _glitchedMythos, [
-        data.text,
-      ]);
+      runCommandWithPermission(
+        PERMISSION_GLITCHED,
+        data,
+        _glitchedMythos,
+        [data.text]
+      );
     },
   };
 

--- a/phasmophobia_evidence_v3/widget.js
+++ b/phasmophobia_evidence_v3/widget.js
@@ -202,15 +202,15 @@ window.addEventListener("onWidgetLoad", function (obj) {
   userState.channelName = obj["detail"]["channel"]["username"];
   const fieldData = obj.detail.fieldData;
 
-  // Sets up all the commands for the widget
-  config.commands = {
-    [fieldData["resetCommand"]]: (data) => {
+  // Declare lambdas (arrow functions) for each command key
+  const commands = {
+    "resetCommand": (data) => {
       runCommandWithPermission(modOrVIPPermission(config), data, _resetGhost, [
         data.text,
         userState,
       ]);
     },
-    [fieldData["nameCommand"]]: (data) => {
+    "nameCommand": (data) => {
       runCommandWithPermission(
         modOrVIPPermission(config),
         data,
@@ -218,7 +218,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [data.text, userState]
       );
     },
-    [fieldData["firstnameCommand"]]: (data) => {
+    "firstnameCommand": (data) => {
       runCommandWithPermission(
         modOrVIPPermission(config),
         data,
@@ -226,7 +226,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [data.text, userState]
       );
     },
-    [fieldData["surnameCommand"]]: (data) => {
+    "surnameCommand": (data) => {
       runCommandWithPermission(
         modOrVIPPermission(config),
         data,
@@ -234,7 +234,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [data.text, userState]
       );
     },
-    [fieldData["locationNameCommand"]]: (data) => {
+    "locationNameCommand": (data) => {
       runCommandWithPermission(
         modOrVIPPermission(config),
         data,
@@ -242,29 +242,29 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [data.text, userState]
       );
     },
-    [fieldData["locationDiffCommand"]]: (data) => {
+    "locationDiffCommand": (data) => {
       runCommandWithPermission(modOrVIPPermission(config), data, _setDiffName, [
         data.text,
         userState,
       ]);
     },
-    [fieldData["bonerCommand"]]: (data) => {
+    "bonerCommand": (data) => {
       runCommandWithPermission(modOrVIPPermission(config), data, _toggleBoner, [
         userState,
       ]);
     },
-    [fieldData["ouijaCommand"]]: (data) => {
+    "ouijaCommand": (data) => {
       runCommandWithPermission(modOrVIPPermission(config), data, _toggleOuija, [
         userState,
       ]);
     },
-    [fieldData["emfCommand"]]: (data) => {
+    "emfCommand": (data) => {
       runCommandWithPermission(modOrVIPPermission(config), data, _toggleEMF, [
         userState,
         config,
       ]);
     },
-    [fieldData["spiritBoxCommand"]]: (data) => {
+    "spiritBoxCommand": (data) => {
       runCommandWithPermission(
         modOrVIPPermission(config),
         data,
@@ -272,7 +272,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [userState, config]
       );
     },
-    [fieldData["fingerprintsCommand"]]: (data) => {
+    "fingerprintsCommand": (data) => {
       runCommandWithPermission(
         modOrVIPPermission(config),
         data,
@@ -280,13 +280,13 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [userState, config]
       );
     },
-    [fieldData["orbsCommand"]]: (data) => {
+    "orbsCommand": (data) => {
       runCommandWithPermission(modOrVIPPermission(config), data, _toggleOrbs, [
         userState,
         config,
       ]);
     },
-    [fieldData["writingCommand"]]: (data) => {
+    "writingCommand": (data) => {
       runCommandWithPermission(
         modOrVIPPermission(config),
         data,
@@ -294,7 +294,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [userState, config]
       );
     },
-    [fieldData["freezingCommand"]]: (data) => {
+    "freezingCommand": (data) => {
       runCommandWithPermission(
         modOrVIPPermission(config),
         data,
@@ -302,7 +302,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [userState, config]
       );
     },
-    [fieldData["dotsCommand"]]: (data) => {
+    "dotsCommand": (data) => {
       runCommandWithPermission(
         modOrVIPPermission(config),
         data,
@@ -310,7 +310,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [userState, config]
       );
     },
-    [fieldData["optionalObjectivesCommand"]]: (data) => {
+    "optionalObjectivesCommand": (data) => {
       runCommandWithPermission(
         modOrVIPPermission(config),
         data,
@@ -318,7 +318,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [data.text, userState]
       );
     },
-    [fieldData["toggleOptObjOneCommand"]]: (data) => {
+    "toggleOptObjOneCommand": (data) => {
       runCommandWithPermission(
         modOrVIPPermission(config),
         data,
@@ -326,7 +326,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [0, userState] // The position in array
       );
     },
-    [fieldData["toggleOptObjTwoCommand"]]: (data) => {
+    "toggleOptObjTwoCommand": (data) => {
       runCommandWithPermission(
         modOrVIPPermission(config),
         data,
@@ -334,7 +334,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [1, userState] // The position in array
       );
     },
-    [fieldData["toggleOptObjThreeCommand"]]: (data) => {
+    "toggleOptObjThreeCommand": (data) => {
       runCommandWithPermission(
         modOrVIPPermission(config),
         data,
@@ -342,17 +342,17 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [2, userState] // The position in array
       );
     },
-    [fieldData["vipToggleOnCommand"]]: (data) => {
+    "vipToggleOnCommand": (data) => {
       runCommandWithPermission(PERMISSION_MOD, data, _toggleVIPAccessibility, [
         true,
       ]);
     },
-    [fieldData["vipToggleOffCommand"]]: (data) => {
+    "vipToggleOffCommand": (data) => {
       runCommandWithPermission(PERMISSION_MOD, data, _toggleVIPAccessibility, [
         false,
       ]);
     },
-    [fieldData["setCounterNameCommand"]]: (data) => {
+    "setCounterNameCommand": (data) => {
       runCommandWithPermission(
         modOrVIPPermission(config),
         data,
@@ -360,7 +360,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [COUNTER_1, data.text]
       );
     },
-    [fieldData["setCounterNumberCommand"]]: (data) => {
+    "setCounterNumberCommand": (data) => {
       runCommandWithPermission(
         modOrVIPPermission(config),
         data,
@@ -368,7 +368,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [COUNTER_1, data.text]
       );
     },
-    [fieldData["incrementCounterCommand"]]: (data) => {
+    "incrementCounterCommand": (data) => {
       runCommandWithPermission(
         modOrVIPPermission(config),
         data,
@@ -376,7 +376,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [COUNTER_1]
       );
     },
-    [fieldData["decrementCounterCommand"]]: (data) => {
+    "decrementCounterCommand": (data) => {
       runCommandWithPermission(
         modOrVIPPermission(config),
         data,
@@ -384,7 +384,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [COUNTER_1]
       );
     },
-    [fieldData["setCounter2NameCommand"]]: (data) => {
+    "setCounter2NameCommand": (data) => {
       runCommandWithPermission(
         modOrVIPPermission(config),
         data,
@@ -392,7 +392,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [COUNTER_2, data.text]
       );
     },
-    [fieldData["setCounter2NumberCommand"]]: (data) => {
+    "setCounter2NumberCommand": (data) => {
       runCommandWithPermission(
         modOrVIPPermission(config),
         data,
@@ -400,7 +400,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [COUNTER_2, data.text]
       );
     },
-    [fieldData["incrementCounter2Command"]]: (data) => {
+    "incrementCounter2Command": (data) => {
       runCommandWithPermission(
         modOrVIPPermission(config),
         data,
@@ -408,7 +408,7 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [COUNTER_2]
       );
     },
-    [fieldData["decrementCounter2Command"]]: (data) => {
+    "decrementCounter2Command": (data) => {
       runCommandWithPermission(
         modOrVIPPermission(config),
         data,
@@ -416,12 +416,23 @@ window.addEventListener("onWidgetLoad", function (obj) {
         [COUNTER_2]
       );
     },
+  };
+
+  // Sets up all the commands for the widget
+  config.commands = {
     "!glitchedmythos": (data) => {
       runCommandWithPermission(PERMISSION_GLITCHED, data, _glitchedMythos, [
         data.text,
       ]);
     },
   };
+
+  // Register comma-delimited command names
+  for (const [key, func] of Object.entries(commands)) {
+    for (const command of fieldData[key].split(',')) {
+      config.commands[command] = func
+    }
+  }
 
   // Configuration based on user choices
   config.allowVIPS = fieldData["allowVIPS"] === "yes" ? true : false;

--- a/phasmophobia_evidence_v3/widget.json
+++ b/phasmophobia_evidence_v3/widget.json
@@ -161,6 +161,18 @@
     "value": "!counter2down",
     "group": "Commands"
   },
+  "allToggleOnCommand": {
+    "type": "string",
+    "label": "Toggle Allowing Everyone on",
+    "value": "!everyon",
+    "group": "Commands"
+  },
+  "allToggleOffCommand": {
+    "type": "string",
+    "label": "Toggle Allowing Everyone off",
+    "value": "!everyoff",
+    "group": "Commands"
+  },
   "vipToggleOnCommand": {
     "type": "string",
     "label": "Toggle Allowing VIPS on",

--- a/phasmophobia_evidence_v3/widget.json
+++ b/phasmophobia_evidence_v3/widget.json
@@ -293,6 +293,16 @@
     },
     "group": "Optionals"
   },
+  "allowAll": {
+    "type": "dropdown",
+    "label": "Allow everyone to use commands",
+    "value": "no",
+    "options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "group": "Optionals"
+  },
   "allowVIPS": {
     "type": "dropdown",
     "label": "Allow VIPS to use commands",


### PR DESCRIPTION
These should probably have been broken out into two separate PRs. The first commit consists of added support to allow a comma-delimited parsing of the command name. The downside to this is that you won't be able to use commas in the command names, even as the trigger. This could probably be made configurable.
The following six commits add a setting and command (default suggested name, since `!allon` and `!alloff` didn't make sense to me, is `!everyon` and `!everyoff`) to allow all viewers to record evidence, etc. Handy for smaller streamers, where not everyone can be a VIP, but most everyone is safe to run the commands.