### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/archive/phasmophobia_evidence_v1/widget.js
+++ b/archive/phasmophobia_evidence_v1/widget.js
@@ -359,7 +359,7 @@ let getImpossibleEvidence = (possibleGhosts) => {
     console.log('going through ghost', possibleGhosts[i])
     for (let k = 0; k < impossibleEvidenceString.length; k++) {
       console.log('values: ', `${+impossibleEvidenceString[k] + +possibleGhosts[i][0][k]}`, `${+impossibleEvidenceString[k]}`, `${+possibleGhosts[i][0][k]}`);
-      impossibleEvidenceString = impossibleEvidenceString.substr(0, k) + `${+impossibleEvidenceString[k] + +possibleGhosts[i][0][k]}` + impossibleEvidenceString.substr(k + 1);
+      impossibleEvidenceString = impossibleEvidenceString.slice(0, k) + `${+impossibleEvidenceString[k] + +possibleGhosts[i][0][k]}` + impossibleEvidenceString.slice(k + 1);
       impossibleEvidenceString[k] = `${+impossibleEvidenceString[k] + +possibleGhosts[i][0][k]}` // possibleGhosts[ghost][ghost evidence string][position in evidence string]
     }
   }

--- a/archive/phasmophobia_evidence_v2/widget.js
+++ b/archive/phasmophobia_evidence_v2/widget.js
@@ -567,7 +567,7 @@ let getImpossibleEvidence = (possibleGhosts) => {
   let impossibleEvidenceString = '000000'; // If it stays a 0, we know it can't match any of the ghosts
   for (let i = 0; i < possibleGhosts.length; i++) {
     for (let k = 0; k < impossibleEvidenceString.length; k++) {
-      impossibleEvidenceString = impossibleEvidenceString.substr(0, k) + `${+impossibleEvidenceString[k] + +possibleGhosts[i].evidence[k]}` + impossibleEvidenceString.substr(k + 1);
+      impossibleEvidenceString = impossibleEvidenceString.slice(0, k) + `${+impossibleEvidenceString[k] + +possibleGhosts[i].evidence[k]}` + impossibleEvidenceString.slice(k + 1);
       impossibleEvidenceString[k] = `${+impossibleEvidenceString[k] + +possibleGhosts[i].evidence[k]}` // possibleGhosts[ghost][ghost evidence string][position in evidence string]
     }
   }

--- a/phasmophobia_evidence_tracker/widget.js
+++ b/phasmophobia_evidence_tracker/widget.js
@@ -905,7 +905,7 @@ const _toggleSighting = (sighting, state) => {
 }
 
 const _togglePossession = (possession, state) => {
-  possession = possession.substr(possession.indexOf(" ") + 1)
+  possession = possession.slice(possession.indexOf(" ") + 1)
   const thisPossession = getValueFromArray(POSSESSIONS, possession);
   for (const [key] of Object.entries(state.cursedPossessions)) {
     state.cursedPossessions[key] = (key === thisPossession) ? !state.cursedPossessions[key] : false;
@@ -1496,9 +1496,9 @@ const getImpossibleEvidence = (possibleGhosts) => {
   for (let i = 0; i < possibleGhosts.length; i++) {
     for (let k = 0; k < impossibleEvidenceString.length; k++) {
       impossibleEvidenceString =
-        impossibleEvidenceString.substr(0, k) +
+        impossibleEvidenceString.slice(0, k) +
         `${+impossibleEvidenceString[k] + +possibleGhosts[i].evidence[k]}` +
-        impossibleEvidenceString.substr(k + 1);
+        impossibleEvidenceString.slice(k + 1);
 
       impossibleEvidenceString[k] = `${
         +impossibleEvidenceString[k] + +possibleGhosts[i].evidence[k]


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.